### PR TITLE
protocol 1.7: outpoint subs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-VERSION = "Electrum Protocol 1.6.x"
+VERSION = "Electrum Protocol 1.7.x"
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -32,6 +32,9 @@ within strings, so no confusion is possible there.  However it does permit newli
 extraneous whitespace between elements; client and server MUST NOT use newlines in such a
 way.
 
+Messages SHOULD be :ref:`padded <padding_messages>` to bucketed lengths,
+and buffered (to introduce delays) to protect against traffic analysis.
+
 If using JSON RPC 2.0's feature of parameter passing by name, the
 names shown in the description of the method or notification in
 question MUST be used.
@@ -259,3 +262,123 @@ and confirm the returned roots match.
   implementation would require hashing approximately 88MB of data to
   provide a single merkle proof.  ElectrumX implements an optimization
   such that it hashes only approximately 180KB of data per proof.
+
+
+.. _padding_messages:
+
+Traffic analysis
+----------------
+
+The goal is to defend against a passive network Man-in-the-Middle, such as an ISP
+or a Tor exit node, observing the encrypted TLS stream, and making educated guesses
+of the message contents based on TCP packet flow: timing, direction, and sizes of TCP packets.
+
+.. note:: When using raw cleartext TCP as transport for the JSON-RPC payloads, without encryption,
+  a passive network observer can see all the plaintext messages.
+
+As a generic mitigation, implementations (both client and server) SHOULD
+
+- pad messages to bucketed lengths (e.g. powers of 2, with a min size), and
+
+- introduce small timing delays, ideally by buffering messages.
+
+(A future protocol version will allow the client to opt-in/opt-out of this server-behaviour,
+but this is not done yet. Opt-out would be useful at least for the timing delays, to avoid
+slowing down CLI scripts, or non-regtest CI functional tests.)
+
+We can fully backwards-compatibly add padding to the JSON-RPC messages by adding extra
+whitespaces inside the JSON objects in a way that parsers ignore.
+This can be done at any protocol version.
+
+For example, instead of sending::
+
+  {"jsonrpc":"2.0","method":"server.version","id":0,"params":["electrum/4.5.8","1.4"]}\n
+
+
+the client could send::
+
+  {"jsonrpc":"2.0","method":"server.version","id":0,"params":["electrum/4.5.8","1.4"]           }\n
+
+
+For better results, both the client and the server SHOULD implement logic to pad the messages
+that they send. So that requests and responses (and notifications) SHOULD all be padded.
+This does not have to be rolled out simultaneously: it is ok for only a client to pad what
+they send and not the server (or the other way around),
+that just limits the effectiveness of the defense against traffic analysis.
+
+Note when the JSON-RPC messages are sent in the TLS stream, they are sometimes batched together.
+That is, a single TCP packet might contain multiple small JSON-RPC messages,
+e.g. if the client tries to send multiple messages in a short burst.
+Also, many protocol requests are <100 bytes, so it would be wasteful to pad all to e.g. 1 kbyte.
+
+To save bandwidth, instead of padding individual JSON-RPC messages,
+participants (the client and the server) COULD implement an application-level buffer,
+write the messages into that buffer, periodically empty the buffer into the TLS stream
+and only add the padding into e.g. the last JSON-RPC message when emptying the buffer.
+
+.. note:: Example implementation
+  in the `Electrum client <https://github.com/spesmilo/electrum/pull/9875>`_
+  and in the `electrumx server <https://github.com/spesmilo/electrumx/pull/301>`_:
+
+  Both the client and the server writes raw JSON-RPC protocol messages into a buffer,
+  which is then occasionally flushed to the wire. When it is flushed, padding is added
+  to round up the total length to 1 KB, or to the next power of 2.
+  The buffer is flushed if it reaches 1 KB, plus there is extra logic that periodically polls
+  if the oldest message in the buffer is older than 1 second, in which case it is also flushed.
+  The worst-case 1 second delay is a performance hit that might in cases be felt by the user.
+  This is a tradeoff to make the flow of packets harder to analyse for an observer.
+
+  Implementations COULD make the buffer size and the max time delay configurable.
+
+.. note:: Many protocol requests are <100 bytes. Contrast that with broadcasting a transaction,
+  which could potentially be several megabytes of data.
+  (max consensus-valid tx is 4 MB, times 2 for hex-encoding)
+  Hence padding to a constant size is not practical.
+  Instead it is recommended to pad to bucketed lengths, e.g. to powers of 2.
+
+The specific details of the size of the buffer, how often it is flushed, and how the padding
+is done is not specified by the protocol at the moment. Consequently, neither the client nor
+the server can enforce the other to pad and much less to delay messages.
+
+.. note:: Some server implementations do not deal with TLS at all,
+  they only implement the raw cleartext TCP protocol, and just recommend operators
+  to put a reverse proxy in front that does TLS termination.
+  Such protocol implementations (both client and server) nevertheless still
+  SHOULD implement all mentioned traffic analysis protections.
+  That way, if the operator tunnels the traffic over TLS externally,
+  the resulting stream meaningfully receives the protections.
+
+.. note:: An alternative approach to the buffer-based delaying and padding
+  could be to more aggressively use JSON-RPC batching to batch messages, and to use the
+  optional Record Padding of
+  `TLS 1.3 <https://www.rfc-editor.org/rfc/rfc8446#section-5.4>`_.
+  See `SSL_CONF_cmd RecordPadding` in openssl. However this only allows
+  padding to multiples of a constant, while above the recommendation was to pad to powers of 2.
+  The implementation might still want to delay messages a bit
+  to accumulate them into a larger JSON-RPC batch. Also note if users
+  (e.g. server operators) are expected to do their own TLS termination
+  (e.g. using a reverse proxy), configuring TLS RecordPadding would become an externality
+  for them to do, which they might forget.
+
+.. note:: Buffering the messages to introduce timing delays
+  and padding to ~bucketed sizes is a good baseline.
+  However even approximate timing and direction of TCP packets
+  can leak too much information in some scenarios.
+
+  To combat timing analysis, both the client and the server
+  COULD send dummy RPCs with a random timer, but more importantly at strategically selected events.
+  For example, when the client receives a new block header notification,
+  it COULD probabilistically send a random number of "server.ping" messages
+  with small random sleeps in-between.
+
+  Protocol version 1.7 extends "server.ping" to make it more useful for mimicking other traffic
+  and adding noise. Now the client can send it either as a JSON-RPC "Request"
+  or JSON-RPC "Notification", and the server can send it as a JSON-RPC "Notification".
+  It can be sent as a notification at any time, without any corresponding prior subscription.
+  If sent as a notification, the receiver is expected not to respond.
+
+  When the server sends a block header notification to the client,
+  it COULD also probabilistically send noise ("server.ping") notifications to the client,
+  perhaps conditioned on whether it will also send
+  :func:`blockchain.scriptpubkey.subscribe` notifications.
+  (so server could send noise if there are no status notifications to be sent)

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -33,7 +33,7 @@ extraneous whitespace between elements; client and server MUST NOT use newlines 
 way.
 
 Messages SHOULD be :ref:`padded <padding_messages>` to bucketed lengths,
-and buffered (to introduce delays) to protect against traffic analysis.
+and COULD be buffered (to introduce delays) to protect against traffic analysis.
 
 If using JSON RPC 2.0's feature of parameter passing by name, the
 names shown in the description of the method or notification in
@@ -276,11 +276,11 @@ of the message contents based on TCP packet flow: timing, direction, and sizes o
 .. note:: When using raw cleartext TCP as transport for the JSON-RPC payloads, without encryption,
   a passive network observer can see all the plaintext messages.
 
-As a generic mitigation, implementations (both client and server) SHOULD
+As a generic mitigation, implementations (both client and server)
 
-- pad messages to bucketed lengths (e.g. powers of 2, with a min size), and
+- SHOULD pad messages to bucketed lengths (e.g. powers of 2, with a min size), and
 
-- introduce small timing delays, ideally by buffering messages.
+- COULD introduce small timing delays, ideally by buffering messages.
 
 (A future protocol version will allow the client to opt-in/opt-out of this server-behaviour,
 but this is not done yet. Opt-out would be useful at least for the timing delays, to avoid
@@ -344,7 +344,7 @@ the server can enforce the other to pad and much less to delay messages.
   they only implement the raw cleartext TCP protocol, and just recommend operators
   to put a reverse proxy in front that does TLS termination.
   Such protocol implementations (both client and server) nevertheless still
-  SHOULD implement all mentioned traffic analysis protections.
+  SHOULD implement traffic analysis protections.
   That way, if the operator tunnels the traffic over TLS externally,
   the resulting stream meaningfully receives the protections.
 

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -76,15 +76,15 @@ All responses received in the stream from and including the server's
 response to this call will use its negotiated protocol version.
 
 
+.. _scriptpubkeys:
 .. _script hashes:
 
 Script Hashes
 -------------
 
 A :dfn:`script hash` is the hash of the binary bytes of the locking
-script (ScriptPubKey), expressed as a hexadecimal string.  The hash
-function to use is given by the "hash_function" member of
-:func:`server.features` (currently :func:`sha256` only).  Like for
+script (scriptPubKey), expressed as a hexadecimal string.  The hash
+function to use is :func:`sha256`.  Like for
 block and transaction hashes, when converting the big-endian binary
 hash to a hexadecimal string the least-significant byte appears first,
 and the most-significant byte last.
@@ -93,7 +93,7 @@ For example, the legacy Bitcoin address from the genesis block::
 
     1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
 
-has P2PKH script::
+has P2PKH script (scriptPubKey)::
 
     76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac
 
@@ -101,11 +101,12 @@ with SHA256 hash::
 
     6191c3b590bfcfa0475e877c302da1e323497acf3b42c08d8fa28e364edf018b
 
-which is sent to the server reversed as::
+the scripthash is defined as the reverse of that::
 
     8b01df4e368ea28f8dc0423bcf7a4923e3a12d307c875e47a0cfbf90b5c39161
 
-By subscribing to this hash you can find P2PKH payments to that address.
+By subscribing to the scriptPubKey or the scripthash,
+you can find P2PKH payments to that address.
 
 One public key, the genesis block public key, among the trillions for
 that address is::
@@ -113,7 +114,7 @@ that address is::
     04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb
     649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f
 
-which has P2PK script::
+which has P2PK script (scriptPubKey)::
 
     4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb
     649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac
@@ -122,11 +123,12 @@ with SHA256 hash::
 
     3318537dfb3135df9f3d950dbdf8a7ae68dd7c7dfef61ed17963ff80f3850474
 
-which is sent to the server reversed as::
+the scripthash is defined as the reverse of that::
 
     740485f380ff6379d11ef6fe7d7cdd68aea7f8bd0d953d9fdf3531fb7d531833
 
-By subscribing to this hash you can find P2PK payments to the genesis
+By subscribing to the scriptPubKey or the scripthash,
+you can find P2PK payments to the genesis
 block public key.
 
 .. note:: The Genesis block coinbase is uniquely unspendable and
@@ -139,10 +141,10 @@ block public key.
 Status
 ------
 
-To calculate the `status` of a :ref:`script hash <script hashes>` (or
-address):
+To calculate the `status` of a :ref:`scriptPubKey <scriptpubkeys>`
+(or :ref:`script hash <script hashes>` or address):
 
-1. Consider all transactions touching the script hash (both those spending
+1. Consider all transactions touching the scriptPubKey (both those spending
 from it, and those funding it), both confirmed and unconfirmed (in mempool).
 
 2. Order confirmed transactions by increasing height (and position in the
@@ -167,21 +169,22 @@ to arrive at a canonical ordering.
 6. Next, with mempool transactions in the specified order, append a similar
 string.
 
-7. The :dfn:`status` of the script hash is the :func:`sha256` hash of the
+7. The :dfn:`status` of the scriptPubKey is the :func:`sha256` hash of the
 full string expressed as a hexadecimal string, or :const:`null` if the
 string is empty because there are no transactions.
 
 
 **Status Example**
 
-Consider the following BTC regtest address: `bcrt1qn7d2x7272lznt5hhk9s07q3cqnrqljnwladrd3`,
-which has script hash: `f04bf26fc16a27abaa2f10540da7a24e369e6ec408f2d901202a7c0cd4a6112d`.
+Consider the following BTC regtest address: `bcrt1qn7d2x7272lznt5hhk9s07q3cqnrqljnwladrd3`.
+That maps to scriptPubKey `00149f9aa3795e57c535d2f7b160ff023804c60fca6e`.
+(and btw has script hash: `f04bf26fc16a27abaa2f10540da7a24e369e6ec408f2d901202a7c0cd4a6112d`)
 
 Example RPC traffic::
 
-    <-- ('blockchain.scripthash.subscribe', ['f04bf26fc16a27abaa2f10540da7a24e369e6ec408f2d901202a7c0cd4a6112d']) {} (id: 15)
+    <-- ('blockchain.scriptpubkey.subscribe', ['00149f9aa3795e57c535d2f7b160ff023804c60fca6e']) {} (id: 15)
     --> 78e96c6562cafa71c115503b9411fdfdc595a45031e2ab76ff75162fe1b0590d (id: 15)
-    <-- ('blockchain.scripthash.get_history', ['f04bf26fc16a27abaa2f10540da7a24e369e6ec408f2d901202a7c0cd4a6112d']) {} (id: 16)
+    <-- ('blockchain.scriptpubkey.get_history', ['00149f9aa3795e57c535d2f7b160ff023804c60fca6e']) {} (id: 16)
     --> [
     {'tx_hash': 'a6c9c361bd0bc536d6a22648efbf8f9b200e425ef6c3a7a9669dc444c532a347', 'height': 2472},
     {'tx_hash': '9c42f84b2fcdaff676ba25d9d4941741cc0d1a01cce0c23fdc4c0b2afa38431c', 'height': 2473},

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -76,15 +76,15 @@ All responses received in the stream from and including the server's
 response to this call will use its negotiated protocol version.
 
 
+.. _scriptpubkeys:
 .. _script hashes:
 
 Script Hashes
 -------------
 
 A :dfn:`script hash` is the hash of the binary bytes of the locking
-script (ScriptPubKey), expressed as a hexadecimal string.  The hash
-function to use is given by the "hash_function" member of
-:func:`server.features` (currently :func:`sha256` only).  Like for
+script (scriptPubKey), expressed as a hexadecimal string.  The hash
+function to use is :func:`sha256`.  Like for
 block and transaction hashes, when converting the big-endian binary
 hash to a hexadecimal string the least-significant byte appears first,
 and the most-significant byte last.
@@ -93,7 +93,7 @@ For example, the legacy Bitcoin address from the genesis block::
 
     1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
 
-has P2PKH script::
+has P2PKH script (scriptPubKey)::
 
     76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac
 
@@ -101,11 +101,12 @@ with SHA256 hash::
 
     6191c3b590bfcfa0475e877c302da1e323497acf3b42c08d8fa28e364edf018b
 
-which is sent to the server reversed as::
+the scripthash is defined as the reverse of that::
 
     8b01df4e368ea28f8dc0423bcf7a4923e3a12d307c875e47a0cfbf90b5c39161
 
-By subscribing to this hash you can find P2PKH payments to that address.
+By subscribing to the scriptPubKey or the scripthash,
+you can find P2PKH payments to that address.
 
 One public key, the genesis block public key, among the trillions for
 that address is::
@@ -113,7 +114,7 @@ that address is::
     04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb
     649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f
 
-which has P2PK script::
+which has P2PK script (scriptPubKey)::
 
     4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb
     649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac
@@ -122,11 +123,12 @@ with SHA256 hash::
 
     3318537dfb3135df9f3d950dbdf8a7ae68dd7c7dfef61ed17963ff80f3850474
 
-which is sent to the server reversed as::
+the scripthash is defined as the reverse of that::
 
     740485f380ff6379d11ef6fe7d7cdd68aea7f8bd0d953d9fdf3531fb7d531833
 
-By subscribing to this hash you can find P2PK payments to the genesis
+By subscribing to the scriptPubKey or the scripthash,
+you can find P2PK payments to the genesis
 block public key.
 
 .. note:: The Genesis block coinbase is uniquely unspendable and
@@ -139,10 +141,10 @@ block public key.
 Status
 ------
 
-To calculate the `status` of a :ref:`script hash <script hashes>` (or
-address):
+To calculate the `status` of a :ref:`scriptPubKey <scriptpubkeys>`
+(or :ref:`script hash <script hashes>` or address):
 
-1. Consider all transactions touching the script hash (both those spending
+1. Consider all transactions touching the scriptPubKey (both those spending
 from it, and those funding it), both confirmed and unconfirmed (in mempool).
 
 2. Order confirmed transactions by increasing height (and position in the
@@ -167,7 +169,7 @@ to arrive at a canonical ordering.
 6. Next, with mempool transactions in the specified order, append a similar
 string.
 
-7. The :dfn:`status` of the script hash is the :func:`sha256` hash of the
+7. The :dfn:`status` of the scriptPubKey is the :func:`sha256` hash of the
 full string expressed as a hexadecimal string, or :const:`null` if the
 string is empty because there are no transactions.
 

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -224,6 +224,30 @@ those two txs are sorted by txid (`80` comes before `e0`).
 Finally, the status is `78e96c6562cafa71c115503b9411fdfdc595a45031e2ab76ff75162fe1b0590d`.
 
 
+.. _blockref:
+
+Block Ref
+---------
+
+To refer to a block in an unambiguous way, the blockhash can be used.
+However, it helps the client to also provide the corresponding height,
+otherwise the client might need to maintain some kind of blockhash->blockheight map,
+which (naively) for a million blocks might take ~50-100 MB of RAM (or disk space).
+
+To save some bandwidth, we can strip the leading zeroes (from the hex representation!)
+of the block hash. We only strip the zero hex characters from the low-entropy end,
+and as the length of the full blockhash is a known constant, this leaves the compressed
+representation unambiguous.
+
+The `blockref` is a `(block_height, compressed_blockhash)` pair, serialized as a json array.
+`block_height` is an integer, the corresponding height for `compressed_blockhash`.
+`compressed_blockhash` is a hex string (but can be odd-length).
+
+Example from Bitcoin mainnet::
+
+    [600000, "7316856900e76b4f7a9139cfbfba89842c8d196cd5f91"]
+
+
 Block Headers
 -------------
 

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -108,7 +108,7 @@ the scripthash is defined as the reverse of that::
 
     8b01df4e368ea28f8dc0423bcf7a4923e3a12d307c875e47a0cfbf90b5c39161
 
-By subscribing to the scriptPubKey or the scripthash,
+By subscribing to the scriptPubKey (or the scripthash in older protocol versions),
 you can find P2PKH payments to that address.
 
 One public key, the genesis block public key, among the trillions for
@@ -130,7 +130,7 @@ the scripthash is defined as the reverse of that::
 
     740485f380ff6379d11ef6fe7d7cdd68aea7f8bd0d953d9fdf3531fb7d531833
 
-By subscribing to the scriptPubKey or the scripthash,
+By subscribing to the scriptPubKey (or the scripthash in older protocol versions),
 you can find P2PK payments to the genesis
 block public key.
 
@@ -320,7 +320,7 @@ and only add the padding into e.g. the last JSON-RPC message when emptying the b
   in the `Electrum client <https://github.com/spesmilo/electrum/pull/9875>`_
   and in the `electrumx server <https://github.com/spesmilo/electrumx/pull/301>`_:
 
-  Both the client and the server writes raw JSON-RPC protocol messages into a buffer,
+  Both the client and the server write raw JSON-RPC protocol messages into a buffer,
   which is then occasionally flushed to the wire. When it is flushed, padding is added
   to round up the total length to 1 KB, or to the next power of 2.
   The buffer is flushed if it reaches 1 KB, plus there is extra logic that periodically polls

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -234,10 +234,9 @@ However, it helps the client to also provide the corresponding height,
 otherwise the client might need to maintain some kind of blockhash->blockheight map,
 which (naively) for a million blocks might take ~50-100 MB of RAM (or disk space).
 
-To save some bandwidth, we can strip the leading zeroes (from the hex representation!)
-of the block hash. We only strip the zero hex characters from the low-entropy end,
-and as the length of the full blockhash is a known constant, this leaves the compressed
-representation unambiguous.
+To save some bandwidth, we strip the leading zeroes (which result from mining difficulty)
+from the hex representation of the block hash. As the length of the full blockhash
+is a known constant, this leaves the compressed representation unambiguous.
 
 The `blockref` is a `(block_height, compressed_blockhash)` pair, serialized as a json array.
 `block_height` is an integer, the corresponding height for `compressed_blockhash`.

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -216,3 +216,17 @@ Removed methods
 
   * :func:`blockchain.relayfee` is removed. The `minrelaytxfee` field
     of the new :func:`mempool.get_info` RPC is a direct replacement.
+
+
+.. _version 1.7:
+
+Version 1.7
+===========
+
+New methods
+-----------
+
+  * :func:`blockchain.outpoint.subscribe` to subscribe to a transaction
+    outpoint, and get a notification when it gets spent.
+  * :func:`blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.
+  * :func:`blockchain.outpoint.get_status` to get current status of a TXO, without subscribing to changes.

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -223,6 +223,12 @@ Removed methods
 Version 1.7
 ===========
 
+Changes
+-------
+
+  * :func:`server.ping` can now also be sent as an unrequested notification, by both the client
+    and the server. The request/response signature also changed.
+
 New methods
 -----------
 

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -246,6 +246,7 @@ New methods
   * :func:`blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.
   * :func:`blockchain.outpoint.get_status` to get current status of a TXO, without subscribing to changes.
   * :func:`blockchain.transaction.testmempoolaccept`
+  * :func:`mempool.recent` to list a few of the latest txs just added to the mempool.
 
 Removed methods
 ---------------

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -234,6 +234,8 @@ Changes
     has been made optional.
   * :func:`server.features` now has a new mandatory field, *method_flavours*,
     which aims to provide some clarity re whether the server supports optional features.
+  * :func:`server.ping` can now be sent by both the client and the server, and both
+    parties must handle and respond to it. The request/response signature also changed.
 
 New methods
 -----------

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -228,6 +228,12 @@ Changes
 
   * The previously required *height* argument for
     :func:`blockchain.transaction.get_merkle` is now optional.
+  * Support for *cp_height* in :func:`blockchain.block.header` and
+    :func:`blockchain.block.headers` has been made optional.
+  * Support for :const:`verbose=true` in :func:`blockchain.transaction.get`
+    has been made optional.
+  * :func:`server.features` now has a new mandatory field, *method_flavours*,
+    which aims to provide some clarity re whether the server supports optional features.
 
 New methods
 -----------

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -226,6 +226,8 @@ Version 1.7
 Changes
 -------
 
+  * The `blockchain.scripthash.*` methods are all replaced with `blockchain.scriptpubkey.*`
+    methods. Note: `sha256(scriptPubKey) == scripthash`.
   * For :func:`blockchain.transaction.get_merkle`, the previously required
     *height* argument is now optional, and the result now includes a
     *block_hash* field.
@@ -241,7 +243,23 @@ Changes
 New methods
 -----------
 
+  * :func:`blockchain.scriptpubkey.get_balance`
+  * :func:`blockchain.scriptpubkey.get_history`
+  * :func:`blockchain.scriptpubkey.get_mempool`
+  * :func:`blockchain.scriptpubkey.listunspent`
+  * :func:`blockchain.scriptpubkey.subscribe`
+  * :func:`blockchain.scriptpubkey.unsubscribe`
   * :func:`blockchain.outpoint.subscribe` to subscribe to a transaction
     outpoint, and get a notification when it gets spent.
   * :func:`blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.
   * :func:`blockchain.outpoint.get_status` to get current status of a TXO, without subscribing to changes.
+
+Removed methods
+---------------
+
+  * :func:`blockchain.scripthash.get_balance`
+  * :func:`blockchain.scripthash.get_history`
+  * :func:`blockchain.scripthash.get_mempool`
+  * :func:`blockchain.scripthash.listunspent`
+  * :func:`blockchain.scripthash.subscribe`
+  * :func:`blockchain.scripthash.unsubscribe`

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -216,3 +216,23 @@ Removed methods
 
   * :func:`blockchain.relayfee` is removed. The `minrelaytxfee` field
     of the new :func:`mempool.get_info` RPC is a direct replacement.
+
+
+.. _version 1.7:
+
+Version 1.7
+===========
+
+Changes
+-------
+
+  * The previously required *height* argument for
+    :func:`blockchain.transaction.get_merkle` is now optional.
+
+New methods
+-----------
+
+  * :func:`blockchain.outpoint.subscribe` to subscribe to a transaction
+    outpoint, and get a notification when it gets spent.
+  * :func:`blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.
+  * :func:`blockchain.outpoint.get_status` to get current status of a TXO, without subscribing to changes.

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -228,11 +228,30 @@ Changes
 
   * :func:`server.ping` can now also be sent as an unrequested notification, by both the client
     and the server. The request/response signature also changed.
+  * The `blockchain.scripthash.*` methods are all replaced with `blockchain.scriptpubkey.*`
+    methods. Note: `sha256(scriptPubKey) == scripthash`.
+  * The `hash_function` field is removed from the :func:`server.features` response.
 
 New methods
 -----------
 
+  * :func:`blockchain.scriptpubkey.get_balance`
+  * :func:`blockchain.scriptpubkey.get_history`
+  * :func:`blockchain.scriptpubkey.get_mempool`
+  * :func:`blockchain.scriptpubkey.listunspent`
+  * :func:`blockchain.scriptpubkey.subscribe`
+  * :func:`blockchain.scriptpubkey.unsubscribe`
   * :func:`blockchain.outpoint.subscribe` to subscribe to a transaction
     outpoint, and get a notification when it gets spent.
   * :func:`blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.
   * :func:`blockchain.outpoint.get_status` to get current status of a TXO, without subscribing to changes.
+
+Removed methods
+---------------
+
+  * :func:`blockchain.scripthash.get_balance`
+  * :func:`blockchain.scripthash.get_history`
+  * :func:`blockchain.scripthash.get_mempool`
+  * :func:`blockchain.scripthash.listunspent`
+  * :func:`blockchain.scripthash.subscribe`
+  * :func:`blockchain.scripthash.unsubscribe`

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -245,6 +245,7 @@ New methods
     outpoint, and get a notification when it gets spent.
   * :func:`blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.
   * :func:`blockchain.outpoint.get_status` to get current status of a TXO, without subscribing to changes.
+  * :func:`blockchain.transaction.testmempoolaccept`
 
 Removed methods
 ---------------

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -226,8 +226,9 @@ Version 1.7
 Changes
 -------
 
-  * The previously required *height* argument for
-    :func:`blockchain.transaction.get_merkle` is now optional.
+  * For :func:`blockchain.transaction.get_merkle`, the previously required
+    *height* argument is now optional, and the result now includes a
+    *block_hash* field.
   * Support for *cp_height* in :func:`blockchain.block.header` and
     :func:`blockchain.block.headers` has been made optional.
   * Support for :const:`verbose=true` in :func:`blockchain.transaction.get`

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -231,6 +231,7 @@ Changes
   * The `blockchain.scripthash.*` methods are all replaced with `blockchain.scriptpubkey.*`
     methods. Note: `sha256(scriptPubKey) == scripthash`.
   * The `hash_function` field is removed from the :func:`server.features` response.
+  * Standardize "history too large" error code for `blockchain.scriptpubkey.*` methods.
 
 New methods
 -----------

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -229,7 +229,12 @@ Changes
   * :func:`server.ping` can now also be sent as an unrequested notification, by both the client
     and the server. The request/response signature also changed.
   * The `blockchain.scripthash.*` methods are all replaced with `blockchain.scriptpubkey.*`
-    methods. Note: `sha256(scriptPubKey) == scripthash`.
+    methods. Note: `sha256(scriptPubKey) == scripthash`. Besides taking a scriptPubKey instead
+    of a scripthash as input param, the new methods also have some minor functional changes.
+      - the notifications for :func:`blockchain.scriptpubkey.subscribe` still contain the scripthash
+      - the protocol now guarantees that a notification is sent even if the `status` of the scriptPubKey
+        did not change but there was a reorg affecting a relevant tx
+      - many RPC results now contain the `chaintip` (and hence return dict instead of array)
   * The `hash_function` field is removed from the :func:`server.features` response.
   * Standardize "history too large" error code for `blockchain.scriptpubkey.*` methods.
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -316,6 +316,10 @@ Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubk
   See :func:`blockchain.scriptpubkey.get_mempool` for how mempool
   transactions are returned.
 
+  If the history of the scriptPubKey is too long (busy address, touched by thousands of txs),
+  and so the server refuses to serve it, it SHOULD send a JSON-RPC error with integer code `10001`
+  to communicate this to the client.
+
 **Result Examples**
 
 ::
@@ -476,6 +480,10 @@ Subscribe to a :ref:`scriptPubKey <scriptpubkeys>`.
 **Result**
 
   The :ref:`status <status>` of the scriptPubKey.
+
+  If the history of the scriptPubKey is too long (busy address, touched by thousands of txs),
+  and so the server refuses to serve it, it SHOULD send a JSON-RPC error with integer code `10001`
+  to communicate this to the client.
 
 **Notifications**
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -853,6 +853,125 @@ When *verbose* is :const:`true` (exact structure depends on bitcoind impl and ve
     -> {"jsonrpc":"2.0","result":{"success":false,"errors":[{"txid":"c13d8d63284853d3417a150cfddcfc62d31cab4b311c9322cb43f979a518ac3a","error":"insufficient fee, rejecting replacement c13d8d63284853d3417a150cfddcfc62d31cab4b311c9322cb43f979a518ac3a, not enough additional fees to relay; 0.00000022 < 0.0000011"}]},"id":4}
 
 
+blockchain.transaction.testmempoolaccept
+========================================
+
+Returns result of mempool acceptance tests indicating if transaction(s) would be accepted by mempool.
+This checks if txs violate the consensus or policy rules.
+
+If multiple txs are passed in, parents must come before children and package policies apply:
+the transactions cannot conflict with any mempool txs or each other. However the txs do not
+necessarily need to be related to each other or form a "package".
+
+**Signature**
+
+  .. function:: blockchain.transaction.testmempoolaccept(raw_txs)
+  .. versionadded:: 1.7
+
+  *raw_txs*
+
+    An array of raw transactions, each as a hexadecimal string.
+    The maximum number of transactions allowed depends on the bitcoind version of the server,
+    but SHOULD be at least 25.
+
+**Result**
+
+  A json array containing the mempool acceptance test result (a dictionary) for each raw tx,
+  in the same order they were passed in.
+
+  Transactions that cannot be fully validated due to failures in other transactions will not contain an 'allowed' field.
+
+  The per-tx dict has the following keys:
+
+  * `txid` (always)
+      * Type: str
+      * Value: The transaction hash in hex
+  * `wtxid` (always)
+      * Type: str
+      * Value: The transaction witness hash in hex
+  * `allowed` (optional)
+      * Type: bool
+      * Value: Whether this tx would be accepted to the mempool.
+        If not present, the tx was not fully validated due to a failure in another tx in the list.
+  * `reason` (optional)
+      * Type: str
+      * Value: Rejection reason or error message describing why the tx would not be accepted into the mempool.
+        Only present if "allowed" is either false or missing, but even then its presence is optional.
+        This message is arbitrary free-from human-readable text, no guarantees re stability or contents at all.
+        This is only there to help debugging.
+
+**Result Example**
+
+Single tx, allowed::
+
+    [
+        {
+            'txid': 'f2f5f9e7a189d97367b4449705e0567408b4d2f3b6ee03119fa7bc7a96313bfc',
+            'wtxid': '9091e488dded52875f308f1305b1beec73cf0c646644c58c1a161170a33ce7e6',
+            'allowed': true
+        }
+    ]
+
+Two txs, allowed::
+
+    [
+        {
+            'txid': 'f2f5f9e7a189d97367b4449705e0567408b4d2f3b6ee03119fa7bc7a96313bfc',
+            'wtxid': '9091e488dded52875f308f1305b1beec73cf0c646644c58c1a161170a33ce7e6',
+            'allowed': true
+        },
+        {
+            'txid': '0b3e3cacd0be5156711eeff30c4124168b3be9890c297b1c02d47a66e2a6f61b',
+            'wtxid': '779a2ffd065ad5243b85c5d716815186607cf0195a604a8cd668ef2093986b4a',
+            'allowed': true
+        }
+    ]
+
+
+Single tx, rejected::
+
+    [
+        {
+            'txid': '9c42f84b2fcdaff676ba25d9d4941741cc0d1a01cce0c23fdc4c0b2afa38431c',
+            'wtxid': 'b3b1045327a9bd21850f07f639a784653c69d7d82b0341829cb8afcb2c0f881e',
+            'allowed': false,
+            'reason': 'missing-inputs'
+        }
+    ]
+
+Two txs, first tx would be okay, but second is not::
+
+    [
+        {
+            'txid': '5cd0bd7d93e1bbd8269563c1d081e893ed4efbd4bf74ad369ce8569e78928a3e',
+            'wtxid': 'ca0404678d8301cdbbcb96c619acc92b54b6fb82c6a9c4c1d6a2f9b0004d1559'},
+        {
+            'txid': 'd79a54959ac68c592687ac1c040f4b2ba223cb18f36552a42beaab776d6305ed',
+            'wtxid': '83996a7f65d8a52238b83d6123fe908ff98ab48db762d201dbf9efbbf67bd4cc',
+            'allowed': false,
+            'reason': 'min relay fee not met, 0 < 15'
+        }
+    ]
+
+Two txs, that already conflict with each other. This illustrates the "allowed" field might not be present in any item::
+
+    [
+        {
+            'txid': 'd79a54959ac68c592687ac1c040f4b2ba223cb18f36552a42beaab776d6305ed',
+            'wtxid': '83996a7f65d8a52238b83d6123fe908ff98ab48db762d201dbf9efbbf67bd4cc',
+            'reason': 'conflict-in-package'
+        },
+        {
+            'txid': '30aa0fb6174fcc6593235301aa7887227958952238f306131b4dbcab6af33c2f',
+            'wtxid': '7ff9fcbf25721c19b04468c5c2f218d950e3b6446e7e1a564fc01304d3c3e3f2',
+            'reason': 'conflict-in-package'
+        }
+    ]
+
+.. note:: The client implicitly trusts the server NOT to broadcast the txs.
+  Conversely, for the `blockchain.transaction.broadcast` RPC, the client trusts the server to DO broadcast the tx.
+
+
 blockchain.transaction.get
 ==========================
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -955,6 +955,7 @@ and height.
   .. function:: blockchain.transaction.get_merkle(tx_hash, height=None)
   .. versionchanged:: 1.7
      *height* argument made optional (previously mandatory)
+     added *block_hash* field to result
 
   *tx_hash*
 
@@ -972,6 +973,10 @@ and height.
   * *block_height*
 
     The height of the block the transaction was confirmed in.
+
+  * *block_hash*
+
+    The hash of the block the transaction was confirmed in, as a hexadecimal string.
 
   * *merkle*
 
@@ -1004,6 +1009,7 @@ and height.
       "2d64851151550e8c4d337f335ee28874401d55b358a66f1bafab2c3e9f48773d"
     ],
     "block_height": 450538,
+    "block_hash": "0000000000000000029bb9b476f1c66403a151f1da007470f8b9c1d9e4b9106d",
     "pos": 710
   }
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -253,20 +253,19 @@ Subscribe to receive block headers when a new block is found.
   block headers to acquire a consistent view of the chain state.
 
 
-blockchain.scripthash.get_balance
-=================================
+blockchain.scriptpubkey.get_balance
+===================================
 
-Return the confirmed and unconfirmed balances of a :ref:`script hash
-<script hashes>`.
+Return the confirmed and unconfirmed balances of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.get_balance(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.get_balance(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
@@ -285,25 +284,24 @@ Return the confirmed and unconfirmed balances of a :ref:`script hash
     "unconfirmed": 23684400
   }
 
-blockchain.scripthash.get_history
-=================================
+blockchain.scriptpubkey.get_history
+===================================
 
-Return the confirmed and unconfirmed history of a :ref:`script hash
-<script hashes>`.
+Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.get_history(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.get_history(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
   A list of confirmed transactions in blockchain order, with the
-  output of :func:`blockchain.scripthash.get_mempool` appended to the
+  output of :func:`blockchain.scriptpubkey.get_mempool` appended to the
   list.  Each confirmed transaction is a dictionary with the following
   keys:
 
@@ -315,7 +313,7 @@ Return the confirmed and unconfirmed history of a :ref:`script hash
 
     The transaction hash in hexadecimal.
 
-  See :func:`blockchain.scripthash.get_mempool` for how mempool
+  See :func:`blockchain.scriptpubkey.get_mempool` for how mempool
   transactions are returned.
 
 **Result Examples**
@@ -343,27 +341,24 @@ Return the confirmed and unconfirmed history of a :ref:`script hash
     }
   ]
 
-blockchain.scripthash.get_mempool
-=================================
+blockchain.scriptpubkey.get_mempool
+===================================
 
-Return the unconfirmed transactions of a :ref:`script hash <script
-hashes>`.
+Return the unconfirmed transactions of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.get_mempool(scripthash)
-  .. versionadded:: 1.1
-  .. versionchanged:: 1.6
-     results must be sorted (previously undefined order)
+  .. function:: blockchain.scriptpubkey.get_mempool(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
   A list of mempool transactions. The order is the same as when computing the
-  :ref:`status <status>` of the script hash.
+  :ref:`status <status>` of the scriptPubKey.
   Each mempool transaction is a dictionary with the following keys:
 
   * *height*
@@ -391,19 +386,19 @@ hashes>`.
   ]
 
 
-blockchain.scripthash.listunspent
-=================================
+blockchain.scriptpubkey.listunspent
+===================================
 
-Return an ordered list of UTXOs sent to a script hash.
+Return an ordered list of UTXOs sent to a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.listunspent(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.listunspent(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
@@ -464,50 +459,59 @@ Return an ordered list of UTXOs sent to a script hash.
 
 .. _subscribed:
 
-blockchain.scripthash.subscribe
-===============================
+blockchain.scriptpubkey.subscribe
+=================================
 
-Subscribe to a script hash.
+Subscribe to a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.subscribe(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.subscribe(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
-  The :ref:`status <status>` of the script hash.
+  The :ref:`status <status>` of the scriptPubKey.
 
 **Notifications**
 
-  The client will receive a notification when the :ref:`status <status>` of the script
-  hash changes.  Its signature is
+  The client will receive a notification when the :ref:`status <status>` of the
+  scriptPubKey changes. Importantly, the notifications use :ref:`script hash <script hashes>`
+  instead of scriptPubKey. The scripthash corresponds to the scriptPubKey from the
+  original request.
+  The client is expected to maintain a mapping scripthash->scriptpubkey, or similar,
+  to be able to figure out what the notification refers to.
+  Notably, this way servers do not have to store in memory the scriptpubkey corresponding
+  to the original request (which can be up to 10 KB in size, as per Bitcoin consensus),
+  only the scripthash (which is fixed size). Also, this limits upstream bandwidth usage
+  of servers.
+  The signature is
 
-    .. function:: blockchain.scripthash.subscribe(scripthash, status)
+    .. function:: blockchain.scriptpubkey.subscribe(scripthash, status)
        :noindex:
 
-blockchain.scripthash.unsubscribe
-=================================
+blockchain.scriptpubkey.unsubscribe
+===================================
 
-Unsubscribe from a script hash, preventing future notifications if its :ref:`status
+Unsubscribe from a scriptPubKey, preventing future notifications if its :ref:`status
 <status>` changes.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.unsubscribe(scripthash)
-  .. versionadded:: 1.4.2
+  .. function:: blockchain.scriptpubkey.unsubscribe(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
-  Returns :const:`True` if the scripthash was subscribed to, otherwise :const:`False`.
+  Returns :const:`True` if the scriptpubkey was subscribed to, otherwise :const:`False`.
   Note that :const:`False` might be returned even for something subscribed to earlier,
   because the server can drop subscriptions in rare circumstances.
 
@@ -1201,6 +1205,8 @@ Return a list of features and services supported by the server.
 **Signature**
 
   .. function:: server.features()
+  .. versionchanged:: 1.7
+     removed *hash_function* field from result
 
 **Result**
 
@@ -1237,14 +1243,6 @@ Return a list of features and services supported by the server.
     The hash of the genesis block.  This is used to detect if a peer
     is connected to one serving a different network.
 
-  * *hash_function*
-
-    The hash function the server uses for :ref:`script hashing
-    <script hashes>`.  The client must use this function to hash
-    pay-to-scripts to produce script hashes to send to the server.
-    The default is "sha256".  "sha256" is currently the only
-    acceptable value.
-
   * *server_version*
 
     A string that identifies the server software.  Should be the same
@@ -1273,7 +1271,6 @@ Return a list of features and services supported by the server.
       "protocol_min": "1.0",
       "pruning": null,
       "server_version": "ElectrumX 1.0.17",
-      "hash_function": "sha256"
   }
 
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -14,6 +14,8 @@ Return the block header at the given height.
   .. versionchanged:: 1.4
      *cp_height* parameter added
   .. versionchanged:: 1.4.1
+  .. versionchanged:: 1.7
+     *cp_height* support made optional
 
   *height*
 
@@ -25,6 +27,10 @@ Return the block header at the given height.
     otherwise the following must hold:
 
       *height* <= *cp_height*
+
+    The server CAN decide not to support a non-zero cp_height value, but if so,
+    it MUST indicate that in its :func:`server.features` response by setting
+    `method_flavours["blockchain.block.header"]["supports_cp_height"]=false`.
 
 **Result**
 
@@ -87,6 +93,8 @@ Return a chunk of block headers from the main chain.
   .. versionchanged:: 1.4.1
   .. versionchanged:: 1.6
      response contains *headers* field instead of *hex*
+  .. versionchanged:: 1.7
+     *cp_height* support made optional
 
   *start_height*
 
@@ -102,6 +110,11 @@ Return a chunk of block headers from the main chain.
     otherwise the following must hold:
 
       *start_height* + (*count* - 1) <= *cp_height*
+
+    The server CAN decide not to support a non-zero cp_height value, but if so,
+    it MUST indicate that in its :func:`server.features` response by setting
+    `method_flavours["blockchain.block.header"]["supports_cp_height"]=false`.
+    (the flavour key `"blockchain.block.header"` is reused with the other header method).
 
 **Result**
 
@@ -540,8 +553,8 @@ as an input (spends it).
     the outpoint. The behaviour is undefined if an incorrect value is provided.
     The server (especially lighter ones such as EPS/BWT) might require this parameter
     to be able to serve the request, in which case the server must indicate so in its
-    :func:`server.features` response, by including an `requires_spk_hint_for_outpoint` key
-    with value `1`.
+    :func:`server.features` response, by setting
+    `method_flavours["blockchain.outpoint.subscribe"]["requires_spk_hint"]=true`.
 
 .. note::  The server MAY automatically clean up subscriptions (unsubscribe the client)
   where the spending transaction is already deeply mined at a reorg-safe height (typically
@@ -751,7 +764,7 @@ with the child being the last element in the array.
 
   *verbose*
 
-    Whether a verbose coin-specific response is required.
+    Whether the verbose bitcoind response is required.
 
 **Result**
 
@@ -857,6 +870,8 @@ Return a raw transaction.
      ignored argument *height* removed
   .. versionchanged:: 1.2
      *verbose* argument added
+  .. versionchanged:: 1.7
+     support of *verbose=true* made optional
 
   *tx_hash*
 
@@ -865,6 +880,10 @@ Return a raw transaction.
   *verbose*
 
     Whether the verbose bitcoind response is required.
+    The server MUST support the verbose=false option (which is the default).
+    The server CAN decide not to support the verbose=true option, but if so,
+    it MUST indicate that in its :func:`server.features` response by setting
+    `method_flavours["blockchain.transaction.get"]["supports_verbose_true"]=false`.
 
 **Result**
 
@@ -1199,6 +1218,8 @@ Return a list of features and services supported by the server.
 **Signature**
 
   .. function:: server.features()
+  .. versionchanged:: 1.7
+     added *method_flavours* field to result
 
 **Result**
 
@@ -1260,6 +1281,18 @@ Return a list of features and services supported by the server.
     there is no pruning limit.  Should be the same as what would
     suffix the letter ``p`` in the IRC real name.
 
+  * *method_flavours*
+
+    A dictionary that describes whether optional features of certain protocol methods
+    are supported by the server. The server might also require an otherwise optional
+    argument to be set by the client, that too should be clearly advertised here.
+    The keys are protocol method name strings, and the values are dictionaries
+    that are specific to the given protocol method.
+
+    If a server supports all functionality defined for the negotiated protocol version,
+    it can just set this to the empty dict (but the `method_flavours` key itself
+    must always be present).
+
 **Example Result**
 
 ::
@@ -1271,7 +1304,11 @@ Return a list of features and services supported by the server.
       "protocol_min": "1.0",
       "pruning": null,
       "server_version": "ElectrumX 1.0.17",
-      "hash_function": "sha256"
+      "hash_function": "sha256",
+      "method_flavours": {
+          "blockchain.outpoint.subscribe": {"requires_spk_hint": true},
+          "blockchain.transaction.get": {"supports_verbose_true": false}
+      }
   }
 
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -266,20 +266,19 @@ Subscribe to receive block headers when a new block is found.
   block headers to acquire a consistent view of the chain state.
 
 
-blockchain.scripthash.get_balance
-=================================
+blockchain.scriptpubkey.get_balance
+===================================
 
-Return the confirmed and unconfirmed balances of a :ref:`script hash
-<script hashes>`.
+Return the confirmed and unconfirmed balances of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.get_balance(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.get_balance(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
@@ -298,25 +297,24 @@ Return the confirmed and unconfirmed balances of a :ref:`script hash
     "unconfirmed": 23684400
   }
 
-blockchain.scripthash.get_history
-=================================
+blockchain.scriptpubkey.get_history
+===================================
 
-Return the confirmed and unconfirmed history of a :ref:`script hash
-<script hashes>`.
+Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.get_history(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.get_history(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
   A list of confirmed transactions in blockchain order, with the
-  output of :func:`blockchain.scripthash.get_mempool` appended to the
+  output of :func:`blockchain.scriptpubkey.get_mempool` appended to the
   list.  Each confirmed transaction is a dictionary with the following
   keys:
 
@@ -328,7 +326,7 @@ Return the confirmed and unconfirmed history of a :ref:`script hash
 
     The transaction hash in hexadecimal.
 
-  See :func:`blockchain.scripthash.get_mempool` for how mempool
+  See :func:`blockchain.scriptpubkey.get_mempool` for how mempool
   transactions are returned.
 
 **Result Examples**
@@ -356,27 +354,24 @@ Return the confirmed and unconfirmed history of a :ref:`script hash
     }
   ]
 
-blockchain.scripthash.get_mempool
-=================================
+blockchain.scriptpubkey.get_mempool
+===================================
 
-Return the unconfirmed transactions of a :ref:`script hash <script
-hashes>`.
+Return the unconfirmed transactions of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.get_mempool(scripthash)
-  .. versionadded:: 1.1
-  .. versionchanged:: 1.6
-     results must be sorted (previously undefined order)
+  .. function:: blockchain.scriptpubkey.get_mempool(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
   A list of mempool transactions. The order is the same as when computing the
-  :ref:`status <status>` of the script hash.
+  :ref:`status <status>` of the scriptPubKey.
   Each mempool transaction is a dictionary with the following keys:
 
   * *height*
@@ -404,19 +399,19 @@ hashes>`.
   ]
 
 
-blockchain.scripthash.listunspent
-=================================
+blockchain.scriptpubkey.listunspent
+===================================
 
-Return an ordered list of UTXOs sent to a script hash.
+Return an ordered list of UTXOs sent to a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.listunspent(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.listunspent(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
@@ -477,50 +472,59 @@ Return an ordered list of UTXOs sent to a script hash.
 
 .. _subscribed:
 
-blockchain.scripthash.subscribe
-===============================
+blockchain.scriptpubkey.subscribe
+=================================
 
-Subscribe to a script hash.
+Subscribe to a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.subscribe(scripthash)
-  .. versionadded:: 1.1
+  .. function:: blockchain.scriptpubkey.subscribe(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
-  The :ref:`status <status>` of the script hash.
+  The :ref:`status <status>` of the scriptPubKey.
 
 **Notifications**
 
-  The client will receive a notification when the :ref:`status <status>` of the script
-  hash changes.  Its signature is
+  The client will receive a notification when the :ref:`status <status>` of the
+  scriptPubKey changes. Importantly, the notifications use :ref:`script hash <script hashes>`
+  instead of scriptPubKey. The scripthash corresponds to the scriptPubKey from the
+  original request.
+  The client is expected to maintain a mapping scripthash->scriptpubkey, or similar,
+  to be able to figure out what the notification refers to.
+  Notably, this way servers do not have to store in memory the scriptpubkey corresponding
+  to the original request (which can be up to 10 KB in size, as per Bitcoin consensus),
+  only the scripthash (which is fixed size). Also, this limits upstream bandwidth usage
+  of servers.
+  The signature is
 
-    .. function:: blockchain.scripthash.subscribe(scripthash, status)
+    .. function:: blockchain.scriptpubkey.subscribe(scripthash, status)
        :noindex:
 
-blockchain.scripthash.unsubscribe
-=================================
+blockchain.scriptpubkey.unsubscribe
+===================================
 
-Unsubscribe from a script hash, preventing future notifications if its :ref:`status
+Unsubscribe from a scriptPubKey, preventing future notifications if its :ref:`status
 <status>` changes.
 
 **Signature**
 
-  .. function:: blockchain.scripthash.unsubscribe(scripthash)
-  .. versionadded:: 1.4.2
+  .. function:: blockchain.scriptpubkey.unsubscribe(scriptpubkey)
+  .. versionadded:: 1.7
 
-  *scripthash*
+  *scriptpubkey*
 
-    The script hash as a hexadecimal string.
+    The scriptPubKey as a hexadecimal string.
 
 **Result**
 
-  Returns :const:`True` if the scripthash was subscribed to, otherwise :const:`False`.
+  Returns :const:`True` if the scriptpubkey was subscribed to, otherwise :const:`False`.
   Note that :const:`False` might be returned even for something subscribed to earlier,
   because the server can drop subscriptions in rare circumstances.
 
@@ -1226,6 +1230,7 @@ Return a list of features and services supported by the server.
   .. function:: server.features()
   .. versionchanged:: 1.7
      added *method_flavours* field to result
+     removed *hash_function* field from result
 
 **Result**
 
@@ -1261,14 +1266,6 @@ Return a list of features and services supported by the server.
 
     The hash of the genesis block.  This is used to detect if a peer
     is connected to one serving a different network.
-
-  * *hash_function*
-
-    The hash function the server uses for :ref:`script hashing
-    <script hashes>`.  The client must use this function to hash
-    pay-to-scripts to produce script hashes to send to the server.
-    The default is "sha256".  "sha256" is currently the only
-    acceptable value.
 
   * *server_version*
 
@@ -1310,7 +1307,6 @@ Return a list of features and services supported by the server.
       "protocol_min": "1.0",
       "pruning": null,
       "server_version": "ElectrumX 1.0.17",
-      "hash_function": "sha256",
       "method_flavours": {
           "blockchain.outpoint.subscribe": {"requires_spk_hint": true},
           "blockchain.transaction.get": {"supports_verbose_true": false}

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -614,7 +614,7 @@ as an input (spends it).
 
   The signature of the notification is
 
-    .. function:: blockchain.outpoint.subscribe([tx_hash, txout_idx], status)
+    .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, status)
        :noindex:
 
 **Full JSON-RPC Example**
@@ -642,7 +642,8 @@ receives a notification.
     "jsonrpc": "2.0",
     "method": "blockchain.outpoint.subscribe",
     "params": [
-      ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1],
+      "1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf",
+      1,
       {
         "height": 1866594,
         "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -511,6 +511,190 @@ Unsubscribe from a script hash, preventing future notifications if its :ref:`sta
   Note that :const:`False` might be returned even for something subscribed to earlier,
   because the server can drop subscriptions in rare circumstances.
 
+blockchain.outpoint.subscribe
+=============================
+
+Subscribe to a transaction outpoint (TXO), to get notifications about its status.
+A status involves up to two transactions: the funding transaction that creates
+the TXO (as one of its outputs), and the spending transaction that uses it
+as an input (spends it).
+
+**Signature**
+
+  .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, spk_hint=None)
+  .. versionadded:: 1.7
+
+  *tx_hash*
+
+    The TXID of the funding transaction as a hexadecimal string.
+    (sometimes called prevout_hash, in inputs)
+
+  *txout_idx*
+
+    The output index, a non-negative integer. (sometimes called prevout_n, in inputs)
+
+  *spk_hint*
+
+    The scriptPubKey (output script) corresponding to the outpoint, as a hexadecimal
+    string. This is optional, and if provided might be used by the server to find
+    the outpoint. The behaviour is undefined if an incorrect value is provided.
+    The server (especially lighter ones such as EPS/BWT) might require this parameter
+    to be able to serve the request, in which case the server must indicate so in its
+    :func:`server.features` response, by including an `requires_spk_hint_for_outpoint` key
+    with value `1`.
+
+.. note::  The server MAY automatically clean up subscriptions (unsubscribe the client)
+  where the spending transaction is already deeply mined at a reorg-safe height (typically
+  100+ blocks deep).
+  Similarly, the server MAY ignore new subscription requests if the spending tx is already
+  mined at a reorg-safe height but it still MUST send at least one full response.
+
+**Result**
+
+  The status of the TXO, taking the mempool into consideration.
+  The output is a dictionary, containing 0, 1, or 3 of the following items:
+
+  * *height*
+
+    The integer height of the block the funding transaction was confirmed in.
+    If the funding transaction is in the mempool; the value is
+    ``0`` if all its inputs are confirmed, and ``-1`` otherwise.
+    This key must be present if and only if there exists a funding transaction
+    (either in the best chain or in the mempool), regardless of spentness.
+
+  * *spender_txhash*
+
+    The TXID of the spending transaction as a hexadecimal string.
+    This key is present if and only if there exists a spending transaction
+    (either in the best chain or in the mempool).
+
+  * *spender_height*
+
+    The integer height of the block the spending transaction was confirmed in.
+    If the spending transaction is in the mempool; the value is
+    ``0`` if all its inputs are confirmed, and ``-1`` otherwise.
+    This key is present if and only if the *spender_txhash* key is present.
+
+**Result Examples**
+
+::
+
+  {}
+
+::
+
+  {
+    "height": 1866594
+  }
+
+::
+
+  {
+    "height": 1866594,
+    "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
+    "spender_height": 0
+  }
+
+**Notifications**
+
+  The client will receive a notification when the `status` of the outpoint changes.
+  That is, any event that changes any field of the `status` dictionary results in a
+  notification. Some examples:
+
+  * a funding/spending tx appearing in the mempool if there was no such tx when the client subbed
+    (note: the server MUST save the subscription even if the outpoint does not exist yet)
+  * funding/spending tx height changing from -1 to 0 as its inputs got mined
+  * funding/spending tx height changing from 0 to a (positive) block height when it gets mined
+  * note that reorgs can change any of the `status` fields and result in notifications
+  * note that mempool replacement (e.g. due to RBF) or mempool eviction (and potentially other
+    mempool quirks) can also change some of the `status` fields and hence result in notifications
+
+  The client MAY receive a notification even if the status did not change
+  (when e.g. there was a reorg changing the blockhash the tx is mined in but not the height).
+
+  The signature of the notification is
+
+    .. function:: blockchain.outpoint.subscribe([tx_hash, txout_idx], status)
+       :noindex:
+
+**Full JSON-RPC Example**
+
+Here is an example where the client sends a request, gets an immediate response,
+and then at some point later - while the connection is still open -
+receives a notification.
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "blockchain.outpoint.subscribe",
+    "params": ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1]
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "result": {"height": 1866594},
+    "id": 4
+  }
+
+  # notification after broadcasting tx 4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09
+  <- {
+    "jsonrpc": "2.0",
+    "method": "blockchain.outpoint.subscribe",
+    "params": [
+      ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1],
+      {
+        "height": 1866594,
+        "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
+        "spender_height": 0
+      }
+    ]
+  }
+
+
+blockchain.outpoint.get_status
+==============================
+
+Get the status of a transaction outpoint (TXO).
+Same as :func:`blockchain.outpoint.subscribe`, but without subscribing to future changes of status
+(i.e. no subsequent notifications).
+
+**Signature**
+
+  .. function:: blockchain.outpoint.get_status(tx_hash, txout_idx, spk_hint=None)
+  .. versionadded:: 1.7
+
+  (same as :func:`blockchain.outpoint.subscribe`)
+
+**Result**
+
+  (same as :func:`blockchain.outpoint.subscribe`)
+
+blockchain.outpoint.unsubscribe
+===============================
+
+Unsubscribe from a transaction outpoint (TXO), preventing future notifications
+if its `status` changes.
+
+**Signature**
+
+  .. function:: blockchain.outpoint.unsubscribe(tx_hash, txout_idx)
+  .. versionadded:: 1.7
+
+  *tx_hash*
+
+    The TXID of the funding transaction as a hexadecimal string.
+
+  *txout_idx*
+
+    The output index, a non-negative integer.
+
+**Result**
+
+  Returns :const:`True` if the outpoint was subscribed to, otherwise :const:`False`.
+  Note that :const:`False` might be returned even for something subscribed to earlier,
+  because the server can drop subscriptions in rare circumstances.
+
 blockchain.transaction.broadcast
 ================================
 
@@ -748,7 +932,9 @@ and height.
 
 **Signature**
 
-  .. function:: blockchain.transaction.get_merkle(tx_hash, height)
+  .. function:: blockchain.transaction.get_merkle(tx_hash, height=None)
+  .. versionchanged:: 1.7
+     *height* argument made optional (previously mandatory)
 
   *tx_hash*
 
@@ -756,7 +942,8 @@ and height.
 
   *height*
 
-    The height at which it was confirmed, an integer.
+    Optionally, the height at which it was confirmed, an integer.
+    Clients are encouraged to provide this field when they can, to reduce server load.
 
 **Result**
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -1252,6 +1252,56 @@ Returns details on the active state of the TX memory pool.
   }
 
 
+mempool.recent
+==============
+
+Return a list of the last 10 transactions to enter the mempool, in arbitrary order.
+Each transaction object contains simplified overview data,
+with the following fields: txid, fee and vsize.
+
+**Signature**
+
+  .. function:: mempool.recent()
+  .. versionadded:: 1.7
+
+**Result**
+
+  An array of dictionaries, each with the following keys:
+
+    * `txid`
+        * Type: hex string
+        * Value: The transaction hash as a hexadecimal string.
+    * `fee`
+        * Type: integer
+        * Value: The fee paid by the transaction, in satoshis.
+    * `vsize`
+        * Type: integer
+        * Value: The virtual size of the transaction, in vbytes.
+
+.. note:: The server should do a best-effort attempt at including txs that just very recently
+  entered the mempool, however most-recent-ness is not guaranteed.
+
+.. note:: The result might contain fewer than 10 items if the mempool is close to empty.
+
+**Example Result**
+
+::
+
+  [
+      {
+          txid: "4b93c138293a7e3dfea6f0a63d944890b5ba571b03cc22d8c66995535e90dce8",
+          fee: 18277,
+          vsize: 2585
+      },
+      {
+          txid: "47182935123ae4e28d6a227a6076deaef222885d1d67e17e1ea02dd69013e5db",
+          fee: 877,
+          vsize: 143
+      },
+      ...
+  ]
+
+
 server.add_peer
 ===============
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -511,6 +511,190 @@ Unsubscribe from a script hash, preventing future notifications if its :ref:`sta
   Note that :const:`False` might be returned even for something subscribed to earlier,
   because the server can drop subscriptions in rare circumstances.
 
+blockchain.outpoint.subscribe
+=============================
+
+Subscribe to a transaction outpoint (TXO), to get notifications about its status.
+A status involves up to two transactions: the funding transaction that creates
+the TXO (as one of its outputs), and the spending transaction that uses it
+as an input (spends it).
+
+**Signature**
+
+  .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, spk_hint=None)
+  .. versionadded:: 1.7
+
+  *tx_hash*
+
+    The TXID of the funding transaction as a hexadecimal string.
+    (sometimes called prevout_hash, in inputs)
+
+  *txout_idx*
+
+    The output index, a non-negative integer. (sometimes called prevout_n, in inputs)
+
+  *spk_hint*
+
+    The scriptPubKey (output script) corresponding to the outpoint, as a hexadecimal
+    string. This is optional, and if provided might be used by the server to find
+    the outpoint. The behaviour is undefined if an incorrect value is provided.
+    Some servers (especially lighter personal servers such as EPS/BWT) might require this parameter
+    to be able to serve the request, due to implementation constraints, but when feasible
+    the server SHOULD NOT require it.
+
+.. note::  The server MAY automatically clean up subscriptions (unsubscribe the client)
+  where the spending transaction is already deeply mined at a reorg-safe height (typically
+  100+ blocks deep).
+  Similarly, the server MAY ignore new subscription requests if the spending tx is already
+  mined at a reorg-safe height but it still MUST send at least one full response.
+
+**Result**
+
+  The status of the TXO, taking the mempool into consideration.
+  The output is a dictionary, containing 0, 1, or 3 of the following items:
+
+  * *funder_height*
+
+    The integer height of the block the funding transaction was confirmed in.
+    If the funding transaction is in the mempool; the value is
+    ``0`` if all its inputs are confirmed, and ``-1`` otherwise.
+    This key must be present if and only if there exists a funding transaction
+    (either in the best chain or in the mempool), regardless of spentness.
+
+  * *spender_txhash*
+
+    The TXID of the spending transaction as a hexadecimal string.
+    This key is present if and only if there exists a spending transaction
+    (either in the best chain or in the mempool).
+
+  * *spender_height*
+
+    The integer height of the block the spending transaction was confirmed in.
+    If the spending transaction is in the mempool; the value is
+    ``0`` if all its inputs are confirmed, and ``-1`` otherwise.
+    This key is present if and only if the *spender_txhash* key is present.
+
+**Result Examples**
+
+::
+
+  {}
+
+::
+
+  {
+    "funder_height": 1866594
+  }
+
+::
+
+  {
+    "funder_height": 1866594,
+    "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
+    "spender_height": 0
+  }
+
+**Notifications**
+
+  The client will receive a notification when the `status` of the outpoint changes.
+  That is, any event that changes any field of the `status` dictionary results in a
+  notification. Some examples:
+
+  * a funding/spending tx appearing in the mempool if there was no such tx when the client subbed
+    (note: the server MUST save the subscription even if the outpoint does not exist yet)
+  * funding/spending tx height changing from -1 to 0 as its inputs got mined
+  * funding/spending tx height changing from 0 to a (positive) block height when it gets mined
+  * note that reorgs can change any of the `status` fields and result in notifications
+  * note that mempool replacement (e.g. due to RBF) or mempool eviction (and potentially other
+    mempool quirks) can also change some of the `status` fields and hence result in notifications
+
+  The client MAY receive a notification even if the status did not change
+  (when e.g. there was a reorg changing the blockhash the tx is mined in but not the height).
+
+  The signature of the notification is
+
+    .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, status)
+       :noindex:
+
+**Full JSON-RPC Example**
+
+Here is an example where the client sends a request, gets an immediate response,
+and then at some point later - while the connection is still open -
+receives a notification.
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "blockchain.outpoint.subscribe",
+    "params": ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1]
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "result": {"funder_height": 1866594},
+    "id": 4
+  }
+
+  # notification after broadcasting tx 4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09
+  <- {
+    "jsonrpc": "2.0",
+    "method": "blockchain.outpoint.subscribe",
+    "params": [
+      "1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf",
+      1,
+      {
+        "funder_height": 1866594,
+        "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
+        "spender_height": 0
+      }
+    ]
+  }
+
+
+blockchain.outpoint.get_status
+==============================
+
+Get the status of a transaction outpoint (TXO).
+Same as :func:`blockchain.outpoint.subscribe`, but without subscribing to future changes of status
+(i.e. no subsequent notifications).
+
+**Signature**
+
+  .. function:: blockchain.outpoint.get_status(tx_hash, txout_idx, spk_hint=None)
+  .. versionadded:: 1.7
+
+  (same as :func:`blockchain.outpoint.subscribe`)
+
+**Result**
+
+  (same as :func:`blockchain.outpoint.subscribe`)
+
+blockchain.outpoint.unsubscribe
+===============================
+
+Unsubscribe from a transaction outpoint (TXO), preventing future notifications
+if its `status` changes.
+
+**Signature**
+
+  .. function:: blockchain.outpoint.unsubscribe(tx_hash, txout_idx)
+  .. versionadded:: 1.7
+
+  *tx_hash*
+
+    The TXID of the funding transaction as a hexadecimal string.
+
+  *txout_idx*
+
+    The output index, a non-negative integer.
+
+**Result**
+
+  Returns :const:`True` if the outpoint was subscribed to, otherwise :const:`False`.
+  Note that :const:`False` might be returned even for something subscribed to earlier,
+  because the server can drop subscriptions in rare circumstances.
+
 blockchain.transaction.broadcast
 ================================
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -521,7 +521,7 @@ as an input (spends it).
 
 **Signature**
 
-  .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, spk_hint=None)
+  .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, spk_hint)
   .. versionadded:: 1.7
 
   *tx_hash*
@@ -535,12 +535,16 @@ as an input (spends it).
 
   *spk_hint*
 
-    The scriptPubKey (output script) corresponding to the outpoint, as a hexadecimal
-    string. This is optional, and if provided might be used by the server to find
-    the outpoint. The behaviour is undefined if an incorrect value is provided.
-    Some servers (especially lighter personal servers such as EPS/BWT) might require this parameter
-    to be able to serve the request, due to implementation constraints, but when feasible
-    the server SHOULD NOT require it.
+    The scriptPubKey (output script) corresponding to the outpoint (prevout), as a hexadecimal
+    string. This helps the server find the outpoint. Behaviour is undefined if
+    an incorrect value is provided.
+
+    .. note::  Full index servers might not need the parameter in practice
+      but some lighter personal servers (such as EPS, BWT, Floresta)
+      would not be able to serve the request without it. A future protocol version might
+      add a feature flag where the server can signal whether it requires spk_hint.
+      Clients should always know the spk_hint in practice, so having to send it
+      is not expected to kill any use case.
 
 .. note::  The server MAY automatically clean up subscriptions (unsubscribe the client)
   where the spending transaction is already deeply mined at a reorg-safe height (typically
@@ -628,7 +632,7 @@ receives a notification.
     "jsonrpc": "2.0",
     "id": 4,
     "method": "blockchain.outpoint.subscribe",
-    "params": ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1]
+    "params": ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1, "0014da28b119a0687c045d87b604667f6773bdc30146"]
   }
   <- {
     "jsonrpc": "2.0",
@@ -661,7 +665,7 @@ Same as :func:`blockchain.outpoint.subscribe`, but without subscribing to future
 
 **Signature**
 
-  .. function:: blockchain.outpoint.get_status(tx_hash, txout_idx, spk_hint=None)
+  .. function:: blockchain.outpoint.get_status(tx_hash, txout_idx, spk_hint)
   .. versionadded:: 1.7
 
   (same as :func:`blockchain.outpoint.subscribe`)

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -1308,18 +1308,112 @@ subscription and the server must send no notifications.
 server.ping
 ===========
 
-Ping the server to ensure it is responding, and to keep the session
+Ping the remote to ensure it is responding, and to keep the session
 alive.  The server may disconnect clients that have sent no requests
 for roughly 10 minutes.
 
+Besides keeping the TCP connection alive, this can also be used
+to obfuscate traffic patterns.
+
+This method can be sent either as a JSON-RPC "Request" or as a JSON-RPC "Notification".
+If sent as a notification, the receiver is expected not to respond.
+This is useful to mimic the traffic pattern of a "useful" notification.
+
+Unlike with other methods, these notifications are not sent as a consequence of prior
+subscriptions. We simply abuse the JSON-RPC "Notification" mechanism to allow
+sending an "unrequested" message that does not warrant a response.
+Both the client and the server MUST tolerate receiving this as an unrequested notification.
+
+  **Note** The client can send this method either as "Request" or as "Notification".
+  The server is only allowed to send it as "Notification".
+  There seems to be no useful traffic pattern that could be mimicked by allowing the server to send
+  this as a request (and getting the client to respond). If one arises, we could
+  relax this in a future version.
+  Allowing the client to send it as "Notification" can be useful as an alternative way
+  to pad its outgoing traffic, in case it does not have direct access to the lower-level
+  JSON-RPC stream to inject whitespaces.
+
 **Signature**
 
-  .. function:: server.ping()
+  .. function:: server.ping(pong_len=0, data="")
   .. versionadded:: 1.2
+  .. versionchanged:: 1.7
+     both parties are now allowed to send this
+     and significant changes to signature/fields
+
+  * *pong_len*
+
+    The number of hex characters the other party should send in the *data* part of the response.
+    A non-negative integer.
+
+  * *data*
+
+    A hexadecimal string (but can be odd-length). Its value is to be ignored by the recipient.
 
 **Result**
 
-  Returns :const:`null`.
+  A dictionary with the following keys:
+
+  * *data*
+
+    A hexadecimal string (but can be odd-length). Its value is to be ignored by the recipient.
+    However, the length MUST match the *pong_len* that was requested.
+
+**Notifications**
+
+    .. function:: server.ping(data="")
+       :noindex:
+
+    * *data*
+
+      See **Result** above.
+
+**Note** The *data* fields should support reasonably long strings, at least as long as
+would be needed to encode the largest consensus-valid transaction. No limits here
+would mean an easy DOS-vector and waste of bandwidth using *pong_len*. The client could
+already send or request transactions using other protocol methods, so limiting below that
+does not make sense.
+
+**Full JSON-RPC Examples**
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "server.ping",
+    "params": [0, "deadbeefdeadbeefdeadbeefdeadbeef"]
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "result": {"data": ""},
+    "id": 4
+  }
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "server.ping",
+    "params": [5]
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "result": {"data": "00000"},
+    "id": 4
+  }
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "method": "server.ping",
+    "params": ["deadbeefdeadbeefdeadbeefdeadbeef"]
+  }
+  (No response. This was a notification.)
+
+
 
 server.version
 ==============

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -1343,18 +1343,117 @@ subscription and the server must send no notifications.
 server.ping
 ===========
 
-Ping the server to ensure it is responding, and to keep the session
+Ping the remote to ensure it is responding, and to keep the session
 alive.  The server may disconnect clients that have sent no requests
 for roughly 10 minutes.
 
+Besides keeping the TCP connection alive, this can also be used
+to obfuscate traffic patterns.
+
+This method can be sent either as a JSON-RPC "Request" or as a JSON-RPC "Notification".
+If sent as a notification, the receiver is expected not to respond.
+This is useful to mimic the traffic pattern of a "useful" notification.
+
+Unlike with other methods, these notifications are not sent as a consequence of prior
+subscriptions. We simply abuse the JSON-RPC "Notification" mechanism to allow
+sending an "unrequested" message that does not warrant a response.
+
+  **Note** This method is special, in that it is symmetric: both the client and
+  the server are allowed to send it (both as a request and as a notification),
+  and both MUST support receiving it and responding to it.
+
 **Signature**
 
-  .. function:: server.ping()
+  .. function:: server.ping(pong_len=0, data="")
   .. versionadded:: 1.2
+  .. versionchanged:: 1.7
+     both parties are now allowed to send this
+     and significant changes to signature/fields
+
+  * *pong_len*
+
+    The number of hex characters the other party should send in the *data* part of the response.
+    A non-negative integer.
+
+  * *data*
+
+    A hexadecimal string. Its value is to be ignored by the recipient.
 
 **Result**
 
-  Returns :const:`null`.
+  A dictionary with the following keys:
+
+  * *data*
+
+    A hexadecimal string. Its value is to be ignored by the recipient.
+    However, the length MUST match the *pong_len* that was requested.
+
+**Notifications**
+
+    .. function:: server.ping(data="")
+       :noindex:
+
+    * *data*
+
+      See **Result** above.
+
+**Note** The *data* fields should support reasonably long strings, at least as long as
+would be needed to encode the largest consensus-valid transaction. No limits here
+would mean an easy DOS-vector and waste of bandwidth using *pong_len*. The client could
+already send or request transactions using other protocol methods, so limiting below that
+does not make sense.
+
+**Full JSON-RPC Examples**
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "server.ping",
+    "params": [0, "deadbeefdeadbeefdeadbeefdeadbeef"]
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "result": {"data": ""},
+    "id": 4
+  }
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "server.ping",
+    "params": [5]
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "result": {"data": "00000"},
+    "id": 4
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "method": "server.ping",
+    "params": [14, "0000000000000000000000000000000000000000000000000000000000000000"]
+  }
+  -> {
+    "jsonrpc": "2.0",
+    "result": {"data": "deadbeefdeadbe"},
+    "id": 7
+  }
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "method": "server.ping",
+    "params": ["deadbeefdeadbeefdeadbeefdeadbeef"]
+  }
+  (No response. This was a notification.)
+
+
 
 server.version
 ==============

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -269,11 +269,21 @@ Return the confirmed and unconfirmed balances of a :ref:`scriptPubKey <scriptpub
 
 **Result**
 
-  A dictionary with keys `confirmed` and `unconfirmed`.  The value of
-  each is the appropriate balance in minimum coin units (satoshis).
-  The `confirmed` balance is the sum of UTXO values at the current chaintip.
-  The value for `unconfirmed` is the mempool delta (compared to `confirmed`),
-  so note that it can also be negative.
+  A dictionary with the following keys:
+
+  * *confirmed*
+
+    The confirmed balance, ignoring mempool events. An integer, in minimum coin units (satoshis).
+    The sum of UTXO values at the current chaintip.
+
+  * *unconfirmed*
+
+    The mempool delta (compared to `confirmed`). An integer, in minimum coin units (satoshis).
+    Note that it can also be negative.
+
+  * *chaintip*
+
+    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
 
 **Result Example**
 
@@ -281,7 +291,8 @@ Return the confirmed and unconfirmed balances of a :ref:`scriptPubKey <scriptpub
 
   {
     "confirmed": 103873966,
-    "unconfirmed": 23684400
+    "unconfirmed": 23684400,
+    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
   }
 
 blockchain.scriptpubkey.get_history
@@ -300,21 +311,29 @@ Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubk
 
 **Result**
 
-  A list of confirmed transactions in blockchain order, with the
-  output of :func:`blockchain.scriptpubkey.get_mempool` appended to the
-  list.  Each confirmed transaction is a dictionary with the following
-  keys:
+  A dictionary, always containing the following two keys:
 
-  * *height*
+  * *chaintip*
 
-    The integer height of the block the transaction was confirmed in.
+    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
 
-  * *tx_hash*
+  * *history*
 
-    The transaction hash in hexadecimal.
+    A list of confirmed transactions in blockchain order, with the corresponding
+    output of :func:`blockchain.scriptpubkey.get_mempool` (its `history` value) appended to the
+    list.  Each confirmed transaction is a dictionary with the following
+    keys:
 
-  See :func:`blockchain.scriptpubkey.get_mempool` for how mempool
-  transactions are returned.
+    * *height*
+
+      The integer height of the block the transaction was confirmed in.
+
+    * *tx_hash*
+
+      The transaction hash in hexadecimal.
+
+    See :func:`blockchain.scriptpubkey.get_mempool` for how mempool
+    transactions are returned.
 
   If the history of the scriptPubKey is too long (busy address, touched by thousands of txs),
   and so the server refuses to serve it, it SHOULD send a JSON-RPC error with integer code `10001`
@@ -324,26 +343,32 @@ Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubk
 
 ::
 
-  [
-    {
-      "height": 200004,
-      "tx_hash": "acc3758bd2a26f869fcc67d48ff30b96464d476bca82c1cd6656e7d506816412"
-    },
-    {
-      "height": 215008,
-      "tx_hash": "f3e1bf48975b8d6060a9de8884296abb80be618dc00ae3cb2f6cee3085e09403"
-    }
-  ]
+  {
+    "history": [
+      {
+        "height": 200004,
+        "tx_hash": "acc3758bd2a26f869fcc67d48ff30b96464d476bca82c1cd6656e7d506816412"
+      },
+      {
+        "height": 215008,
+        "tx_hash": "f3e1bf48975b8d6060a9de8884296abb80be618dc00ae3cb2f6cee3085e09403"
+      }
+    ],
+    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+  }
 
 ::
 
-  [
-    {
-      "fee": 20000,
-      "height": 0,
-      "tx_hash": "9fbed79a1e970343fcd39f4a2d830a6bde6de0754ed2da70f489d0303ed558ec"
-    }
-  ]
+  {
+    "history": [
+      {
+        "fee": 20000,
+        "height": 0,
+        "tx_hash": "9fbed79a1e970343fcd39f4a2d830a6bde6de0754ed2da70f489d0303ed558ec"
+      }
+    ],
+    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+  }
 
 blockchain.scriptpubkey.get_mempool
 ===================================
@@ -361,33 +386,44 @@ Return the unconfirmed transactions of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Result**
 
-  A list of mempool transactions. The order is the same as when computing the
-  :ref:`status <status>` of the scriptPubKey.
-  Each mempool transaction is a dictionary with the following keys:
+  A dictionary, always containing the following two keys:
 
-  * *height*
+  * *chaintip*
 
-    ``0`` if all inputs are confirmed, and ``-1`` otherwise.
+    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
 
-  * *tx_hash*
+  * *history*
 
-    The transaction hash in hexadecimal.
+    A list of mempool transactions. The order is the same as when computing the
+    :ref:`status <status>` of the scriptPubKey.
+    Each mempool transaction is a dictionary with the following keys:
 
-  * *fee*
+    * *height*
 
-    The transaction fee in minimum coin units (satoshis).
+      ``0`` if all inputs are confirmed, and ``-1`` otherwise.
+
+    * *tx_hash*
+
+      The transaction hash in hexadecimal.
+
+    * *fee*
+
+      The transaction fee in minimum coin units (satoshis).
 
 **Result Example**
 
 ::
 
-  [
-    {
-      "tx_hash": "45381031132c57b2ff1cbe8d8d3920cf9ed25efd9a0beb764bdb2f24c7d1c7e3",
-      "height": 0,
-      "fee": 24310
-    }
-  ]
+  {
+    "history": [
+      {
+        "tx_hash": "45381031132c57b2ff1cbe8d8d3920cf9ed25efd9a0beb764bdb2f24c7d1c7e3",
+        "height": 0,
+        "fee": 24310
+      }
+    ],
+    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+  }
 
 
 blockchain.scriptpubkey.listunspent
@@ -406,29 +442,37 @@ Return an ordered list of UTXOs sent to a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Result**
 
-  A list of unspent outputs in blockchain order.  This function takes
-  the mempool into account.  Mempool transactions paying to the
-  address are included at the end of the list in an undefined order.
-  Any output that is spent in the mempool does not appear.  Each
-  output is a dictionary with the following keys:
+  A dictionary, always containing the following two keys:
 
-  * *height*
+  * *chaintip*
 
-    The integer height of the block the transaction was confirmed in.
-    ``0`` if the transaction is in the mempool.
+    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
 
-  * *tx_pos*
+  * *utxos*
 
-    The zero-based index of the output in the transaction's list of
-    outputs.
+    A list of unspent outputs in blockchain order.  This function takes
+    the mempool into account.  Mempool transactions paying to the
+    address are included at the end of the list in an undefined order.
+    Any output that is spent in the mempool does not appear.  Each
+    output is a dictionary with the following keys:
 
-  * *tx_hash*
+    * *height*
 
-    The output's transaction hash as a hexadecimal string.
+      The integer height of the block the transaction was confirmed in.
+      ``0`` if the transaction is in the mempool.
 
-  * *value*
+    * *tx_pos*
 
-    The output's value in minimum coin units (satoshis).
+      The zero-based index of the output in the transaction's list of
+      outputs.
+
+    * *tx_hash*
+
+      The output's transaction hash as a hexadecimal string.
+
+    * *value*
+
+      The output's value in minimum coin units (satoshis).
 
 
 **Warning**
@@ -446,20 +490,23 @@ Return an ordered list of UTXOs sent to a :ref:`scriptPubKey <scriptpubkeys>`.
 
 ::
 
-  [
-    {
-      "tx_pos": 0,
-      "value": 45318048,
-      "tx_hash": "9f2c45a12db0144909b5db269415f7319179105982ac70ed80d76ea79d923ebf",
-      "height": 437146
-    },
-    {
-      "tx_pos": 0,
-      "value": 919195,
-      "tx_hash": "3d2290c93436a3e964cfc2f0950174d8847b1fbe3946432c4784e168da0f019f",
-      "height": 441696
-    }
-  ]
+  {
+    "utxos": [
+      {
+        "tx_pos": 0,
+        "value": 45318048,
+        "tx_hash": "9f2c45a12db0144909b5db269415f7319179105982ac70ed80d76ea79d923ebf",
+        "height": 437146
+      },
+      {
+        "tx_pos": 0,
+        "value": 919195,
+        "tx_hash": "3d2290c93436a3e964cfc2f0950174d8847b1fbe3946432c4784e168da0f019f",
+        "height": 441696
+      }
+    ],
+    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+  }
 
 .. _subscribed:
 
@@ -488,7 +535,13 @@ Subscribe to a :ref:`scriptPubKey <scriptpubkeys>`.
 **Notifications**
 
   The client will receive a notification when the :ref:`status <status>` of the
-  scriptPubKey changes. Importantly, the notifications use :ref:`script hash <script hashes>`
+  scriptPubKey changes.
+
+  The client MAY receive a notification even if the status did not change.
+  One such example is a reorg changing the blockhash, but not the height, a relevant tx is mined in,
+  in which case the client MUST get a notification.
+
+  Importantly, the notifications use :ref:`script hash <script hashes>`
   instead of scriptPubKey. The scripthash corresponds to the scriptPubKey from the
   original request.
   The client is expected to maintain a mapping scripthash->scriptpubkey, or similar,
@@ -497,6 +550,7 @@ Subscribe to a :ref:`scriptPubKey <scriptpubkeys>`.
   to the original request (which can be up to 10 KB in size, as per Bitcoin consensus),
   only the scripthash (which is fixed size). Also, this limits upstream bandwidth usage
   of servers.
+
   The signature is
 
     .. function:: blockchain.scriptpubkey.subscribe(scripthash, status)
@@ -565,8 +619,13 @@ as an input (spends it).
 
 **Result**
 
-  The status of the TXO, taking the mempool into consideration.
-  The output is a dictionary, containing 0, 1, or 3 of the following items:
+  The status of the TXO (taking the mempool into consideration).
+  The output is a dictionary, containing some of the following items:
+
+  * *chaintip*
+
+    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
+    This key is always present.
 
   * *funder_height*
 
@@ -593,17 +652,21 @@ as an input (spends it).
 
 ::
 
-  {}
+  {
+    "chaintip": [1866590, "985ea6ada82aa9f71b11f7b57a8c87e36e6c98e92b9820c4ca"]
+  }
 
 ::
 
   {
+    "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
     "funder_height": 1866594
   }
 
 ::
 
   {
+    "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
     "funder_height": 1866594,
     "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
     "spender_height": 0
@@ -611,9 +674,10 @@ as an input (spends it).
 
 **Notifications**
 
-  The client will receive a notification when the `status` of the outpoint changes.
-  That is, any event that changes any field of the `status` dictionary results in a
-  notification. Some examples:
+  The client will receive a notification when the `status` of the outpoint changes, disregarding
+  changes to the `chaintip` item.
+  That is, any event that changes any field of the `status` dictionary (except the `chaintip` field)
+  results in a notification. Some examples:
 
   * a funding/spending tx appearing in the mempool if there was no such tx when the client subscribed
     (note: the server MUST save the subscription even if the outpoint does not exist yet)
@@ -623,8 +687,9 @@ as an input (spends it).
   * note that mempool replacement (e.g. due to RBF) or mempool eviction (and potentially other
     mempool quirks) can also change some of the `status` fields and hence result in notifications
 
-  The client MAY receive a notification even if the status did not change
-  (when e.g. there was a reorg changing the blockhash the tx is mined in but not the height).
+  The client MAY receive a notification even if the status did not change.
+  One such example is a reorg changing the blockhash, but not the height, a relevant tx is mined in,
+  in which case the client MUST get a notification.
 
   The signature of the notification is
 
@@ -647,7 +712,10 @@ receives a notification.
   }
   <- {
     "jsonrpc": "2.0",
-    "result": {"funder_height": 1866594},
+    "result": {
+      "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
+      "funder_height": 1866594,
+    },
     "id": 4
   }
 
@@ -659,6 +727,7 @@ receives a notification.
       "1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf",
       1,
       {
+        "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
         "funder_height": 1866594,
         "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
         "spender_height": 0

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -553,8 +553,7 @@ as an input (spends it).
 
     .. note::  Full index servers might not need the parameter in practice
       but some lighter personal servers (such as EPS, BWT, Floresta)
-      would not be able to serve the request without it. A future protocol version might
-      add a feature flag where the server can signal whether it requires spk_hint.
+      would not be able to serve the request without it.
       Clients should always know the spk_hint in practice, so having to send it
       is not expected to kill any use case.
 
@@ -616,7 +615,7 @@ as an input (spends it).
   That is, any event that changes any field of the `status` dictionary results in a
   notification. Some examples:
 
-  * a funding/spending tx appearing in the mempool if there was no such tx when the client subbed
+  * a funding/spending tx appearing in the mempool if there was no such tx when the client subscribed
     (note: the server MUST save the subscription even if the outpoint does not exist yet)
   * funding/spending tx height changing from -1 to 0 as its inputs got mined
   * funding/spending tx height changing from 0 to a (positive) block height when it gets mined

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -615,7 +615,8 @@ as an input (spends it).
   where the spending transaction is already deeply mined at a reorg-safe height (typically
   100+ blocks deep).
   Similarly, the server MAY ignore new subscription requests if the spending tx is already
-  mined at a reorg-safe height but it still MUST send at least one full response.
+  mined at a reorg-safe height but it still MUST send the full response to the subscription request
+  (just not the subsequent notifications - which likely would never trigger anyway without a deep reorg).
 
 **Result**
 

--- a/docs/protocol-removed.rst
+++ b/docs/protocol-removed.rst
@@ -350,6 +350,269 @@ This feerate does not guarantee acceptance into the mempool of the server.
    0.0
 
 
+blockchain.scripthash.get_balance
+=================================
+
+Return the confirmed and unconfirmed balances of a :ref:`script hash
+<script hashes>`.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.get_balance(scripthash)
+  .. versionadded:: 1.1
+  .. deprecated:: removed in version 1.7
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A dictionary with keys `confirmed` and `unconfirmed`.  The value of
+  each is the appropriate balance in minimum coin units (satoshis).
+  The `confirmed` balance is the sum of UTXO values at the current chaintip.
+  The value for `unconfirmed` is the mempool delta (compared to `confirmed`),
+  so note that it can also be negative.
+
+**Result Example**
+
+::
+
+  {
+    "confirmed": 103873966,
+    "unconfirmed": 23684400
+  }
+
+blockchain.scripthash.get_history
+=================================
+
+Return the confirmed and unconfirmed history of a :ref:`script hash
+<script hashes>`.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.get_history(scripthash)
+  .. versionadded:: 1.1
+  .. deprecated:: removed in version 1.7
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A list of confirmed transactions in blockchain order, with the
+  output of :func:`blockchain.scripthash.get_mempool` appended to the
+  list.  Each confirmed transaction is a dictionary with the following
+  keys:
+
+  * *height*
+
+    The integer height of the block the transaction was confirmed in.
+
+  * *tx_hash*
+
+    The transaction hash in hexadecimal.
+
+  See :func:`blockchain.scripthash.get_mempool` for how mempool
+  transactions are returned.
+
+**Result Examples**
+
+::
+
+  [
+    {
+      "height": 200004,
+      "tx_hash": "acc3758bd2a26f869fcc67d48ff30b96464d476bca82c1cd6656e7d506816412"
+    },
+    {
+      "height": 215008,
+      "tx_hash": "f3e1bf48975b8d6060a9de8884296abb80be618dc00ae3cb2f6cee3085e09403"
+    }
+  ]
+
+::
+
+  [
+    {
+      "fee": 20000,
+      "height": 0,
+      "tx_hash": "9fbed79a1e970343fcd39f4a2d830a6bde6de0754ed2da70f489d0303ed558ec"
+    }
+  ]
+
+blockchain.scripthash.get_mempool
+=================================
+
+Return the unconfirmed transactions of a :ref:`script hash <script
+hashes>`.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.get_mempool(scripthash)
+  .. versionadded:: 1.1
+  .. versionchanged:: 1.6
+     results must be sorted (previously undefined order)
+  .. deprecated:: removed in version 1.7
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A list of mempool transactions. The order is the same as when computing the
+  :ref:`status <status>` of the script hash.
+  Each mempool transaction is a dictionary with the following keys:
+
+  * *height*
+
+    ``0`` if all inputs are confirmed, and ``-1`` otherwise.
+
+  * *tx_hash*
+
+    The transaction hash in hexadecimal.
+
+  * *fee*
+
+    The transaction fee in minimum coin units (satoshis).
+
+**Result Example**
+
+::
+
+  [
+    {
+      "tx_hash": "45381031132c57b2ff1cbe8d8d3920cf9ed25efd9a0beb764bdb2f24c7d1c7e3",
+      "height": 0,
+      "fee": 24310
+    }
+  ]
+
+
+blockchain.scripthash.listunspent
+=================================
+
+Return an ordered list of UTXOs sent to a script hash.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.listunspent(scripthash)
+  .. versionadded:: 1.1
+  .. deprecated:: removed in version 1.7
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  A list of unspent outputs in blockchain order.  This function takes
+  the mempool into account.  Mempool transactions paying to the
+  address are included at the end of the list in an undefined order.
+  Any output that is spent in the mempool does not appear.  Each
+  output is a dictionary with the following keys:
+
+  * *height*
+
+    The integer height of the block the transaction was confirmed in.
+    ``0`` if the transaction is in the mempool.
+
+  * *tx_pos*
+
+    The zero-based index of the output in the transaction's list of
+    outputs.
+
+  * *tx_hash*
+
+    The output's transaction hash as a hexadecimal string.
+
+  * *value*
+
+    The output's value in minimum coin units (satoshis).
+
+
+**Warning**
+
+  In the case of pre-segwit legacy UTXOs, the satoshi value claimed by a server should be
+  verified by the client by requesting the full funding transaction and parsing it
+  to look for the output amount corresponding to ``tx_hash:tx_pos``.
+  This is necessary as the pre-segwit legacy sighash does not commit to the input amount, so
+  the server could try to trick a client into burning their coins as fees.
+  Note that it is not necessary to SPV-verify ``tx_hash``, as the sighash commits to the txid,
+  and the txid commits to the raw tx, from which we read out the satoshi amount.
+
+
+**Result Example**
+
+::
+
+  [
+    {
+      "tx_pos": 0,
+      "value": 45318048,
+      "tx_hash": "9f2c45a12db0144909b5db269415f7319179105982ac70ed80d76ea79d923ebf",
+      "height": 437146
+    },
+    {
+      "tx_pos": 0,
+      "value": 919195,
+      "tx_hash": "3d2290c93436a3e964cfc2f0950174d8847b1fbe3946432c4784e168da0f019f",
+      "height": 441696
+    }
+  ]
+
+blockchain.scripthash.subscribe
+===============================
+
+Subscribe to a script hash.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.subscribe(scripthash)
+  .. versionadded:: 1.1
+  .. deprecated:: removed in version 1.7
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  The :ref:`status <status>` of the script hash.
+
+**Notifications**
+
+  The client will receive a notification when the :ref:`status <status>` of the script
+  hash changes.  Its signature is
+
+    .. function:: blockchain.scripthash.subscribe(scripthash, status)
+       :noindex:
+
+blockchain.scripthash.unsubscribe
+=================================
+
+Unsubscribe from a script hash, preventing future notifications if its :ref:`status
+<status>` changes.
+
+**Signature**
+
+  .. function:: blockchain.scripthash.unsubscribe(scripthash)
+  .. versionadded:: 1.4.2
+  .. deprecated:: removed in version 1.7
+
+  *scripthash*
+
+    The script hash as a hexadecimal string.
+
+**Result**
+
+  Returns :const:`True` if the scripthash was subscribed to, otherwise :const:`False`.
+  Note that :const:`False` might be returned even for something subscribed to earlier,
+  because the server can drop subscriptions in rare circumstances.
+
+
 server.version
 ==============
 


### PR DESCRIPTION
This defines a new Electrum Protocol version: 1.7.

changes compared to 1.6:
- the `blockchain.scripthash.*` methods are all replaced with `blockchain.scriptpubkey.*` methods
  - ref https://github.com/spesmilo/electrum-protocol/issues/3
  - ~~the new methods also contain the `chaintip` in their response~~
    - reverted in https://github.com/spesmilo/electrum-protocol/pull/17
- new RPCs: `blockchain.outpoint.subscribe` RPC (and related RPCs) to subscribe to a transaction
  outpoint, and get a notification when it gets spent.
- `server.ping` can now also be sent as an unrequested notification, by both the client
  and the server. The request/response signature also changed.
- standardize "history too large" error code for `blockchain.scriptpubkey.*` methods
- new RPC: `blockchain.transaction.testmempoolaccept`
  - ref https://github.com/spesmilo/electrum-protocol/issues/11 
- new RPC: `mempool.recent` to list a few of the latest txs just added to the mempool.
  - ref https://github.com/spesmilo/electrum-protocol/issues/13

---

This proposal is less ambitious than previous drafts of 1.7:
- most notably witness SPV is postponed
  - ref https://github.com/spesmilo/electrum-protocol/pull/16
- the `method_flavours` field for the `server.features` response is also postponed,
  as I realised we are not clear re how to signal/negotiate optional features
  - see related https://github.com/spesmilo/electrum-protocol/issues/7 idea
- `blockchain.outpoint.subscribe` requires `spk_hint` as an input param, to help server impls

---

We have a client implementation in https://github.com/spesmilo/electrum/pull/10627,
and a server implementation in https://github.com/spesmilo/electrumx/pull/303.

---

EDIT: note that https://github.com/spesmilo/electrum-protocol/pull/17 was an after-merge revert, which reverted adding the chaintip to RPC responses