### PR TITLE
clarify relayfee method and add blockchain.mempoolminfee method

### DIFF
--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -260,6 +260,29 @@ This feerate does not guarantee acceptance into the mempool of the server.
 
    0.0
 
+blockchain.mempoolminfee
+========================
+
+Minimum fee rate in BTC/kvB for a transaction to be accepted into the servers mempool.
+
+**Signature**
+
+  .. function:: blockchain.mempoolminfee()
+
+**Result**
+
+  The BTC/kvB fee in whole coin units (BTC, not satoshis) as a floating point number.
+
+**Example Results**
+
+::
+
+   0.00002123
+
+::
+
+   0.00001000
+
 blockchain.scripthash.get_balance
 =================================
 


### PR DESCRIPTION
The description of `blockchain.relayfee()` promises the user that
transactions paying the relayfee will get accepted into the servers
mempool. This however seems incorrect as the relayfee is just a
fixed value in the core backend (either configured or a hardcoded default value)
and doesn't change with a growing mempool.
See definition:
https://github.com/bitcoin/bitcoin/blob/d387b8ec15e553db9b9c370314ee359e981fb374/src/main.cpp#L55-L56
and usage for the API:
https://github.com/bitcoin/bitcoin/blob/d387b8ec15e553db9b9c370314ee359e981fb374/src/rpcmisc.cpp#L86-L87

To get the minimal feerate to be paid for mempool acceptance one has to
use getmempoolinfo['mempoolminfee'] being added here as `blockchain.mempoolminfee()`
This can be useful for things like lightning anchor commitment tx fees as discussed here:
https://github.com/spesmilo/electrum/pull/9826