### PR TITLE
protocol 1.7: revert adding chaintip to responses

### DIFF
--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -224,29 +224,6 @@ those two txs are sorted by txid (`80` comes before `e0`).
 Finally, the status is `78e96c6562cafa71c115503b9411fdfdc595a45031e2ab76ff75162fe1b0590d`.
 
 
-.. _blockref:
-
-Block Ref
----------
-
-To refer to a block in an unambiguous way, the blockhash can be used.
-However, it helps the client to also provide the corresponding height,
-otherwise the client might need to maintain some kind of blockhash->blockheight map,
-which (naively) for a million blocks might take ~50-100 MB of RAM (or disk space).
-
-To save some bandwidth, we strip the leading zeroes (which result from mining difficulty)
-from the hex representation of the block hash. As the length of the full blockhash
-is a known constant, this leaves the compressed representation unambiguous.
-
-The `blockref` is a `(block_height, compressed_blockhash)` pair, serialized as a json array.
-`block_height` is an integer, the corresponding height for `compressed_blockhash`.
-`compressed_blockhash` is a hex string (but can be odd-length).
-
-Example from Bitcoin mainnet::
-
-    [600000, "7316856900e76b4f7a9139cfbfba89842c8d196cd5f91"]
-
-
 Block Headers
 -------------
 

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -234,7 +234,7 @@ Changes
       - the notifications for :func:`blockchain.scriptpubkey.subscribe` still contain the scripthash
       - the protocol now guarantees that a notification is sent even if the `status` of the scriptPubKey
         did not change but there was a reorg affecting a relevant tx
-      - many RPC results now contain the `chaintip` (and hence return dict instead of array)
+      - many RPCs now return a dict instead of an array
   * The `hash_function` field is removed from the :func:`server.features` response.
   * Standardize "history too large" error code for `blockchain.scriptpubkey.*` methods.
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -281,18 +281,13 @@ Return the confirmed and unconfirmed balances of a :ref:`scriptPubKey <scriptpub
     The mempool delta (compared to `confirmed`). An integer, in minimum coin units (satoshis).
     Note that it can also be negative.
 
-  * *chaintip*
-
-    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
-
 **Result Example**
 
 ::
 
   {
     "confirmed": 103873966,
-    "unconfirmed": 23684400,
-    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+    "unconfirmed": 23684400
   }
 
 blockchain.scriptpubkey.get_history
@@ -311,11 +306,7 @@ Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubk
 
 **Result**
 
-  A dictionary, always containing the following two keys:
-
-  * *chaintip*
-
-    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
+  A dictionary, always containing the following single key:
 
   * *history*
 
@@ -353,8 +344,7 @@ Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubk
         "height": 215008,
         "tx_hash": "f3e1bf48975b8d6060a9de8884296abb80be618dc00ae3cb2f6cee3085e09403"
       }
-    ],
-    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+    ]
   }
 
 ::
@@ -366,8 +356,7 @@ Return the confirmed and unconfirmed history of a :ref:`scriptPubKey <scriptpubk
         "height": 0,
         "tx_hash": "9fbed79a1e970343fcd39f4a2d830a6bde6de0754ed2da70f489d0303ed558ec"
       }
-    ],
-    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+    ]
   }
 
 blockchain.scriptpubkey.get_mempool
@@ -386,11 +375,7 @@ Return the unconfirmed transactions of a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Result**
 
-  A dictionary, always containing the following two keys:
-
-  * *chaintip*
-
-    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
+  A dictionary, always containing the following single key:
 
   * *history*
 
@@ -421,8 +406,7 @@ Return the unconfirmed transactions of a :ref:`scriptPubKey <scriptpubkeys>`.
         "height": 0,
         "fee": 24310
       }
-    ],
-    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+    ]
   }
 
 
@@ -442,11 +426,7 @@ Return an ordered list of UTXOs sent to a :ref:`scriptPubKey <scriptpubkeys>`.
 
 **Result**
 
-  A dictionary, always containing the following two keys:
-
-  * *chaintip*
-
-    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
+  A dictionary, always containing the following single key:
 
   * *utxos*
 
@@ -504,8 +484,7 @@ Return an ordered list of UTXOs sent to a :ref:`scriptPubKey <scriptpubkeys>`.
         "tx_hash": "3d2290c93436a3e964cfc2f0950174d8847b1fbe3946432c4784e168da0f019f",
         "height": 441696
       }
-    ],
-    "chaintip": [951234, "a3e3f7037123b11b4dac1ff08ad2732dba903a03623f"]
+    ]
   }
 
 .. _subscribed:
@@ -623,11 +602,6 @@ as an input (spends it).
   The status of the TXO (taking the mempool into consideration).
   The output is a dictionary, containing some of the following items:
 
-  * *chaintip*
-
-    A :ref:`blockref <blockref>` for the current chaintip (latest block in most work chain).
-    This key is always present.
-
   * *funder_height*
 
     The integer height of the block the funding transaction was confirmed in.
@@ -653,21 +627,17 @@ as an input (spends it).
 
 ::
 
-  {
-    "chaintip": [1866590, "985ea6ada82aa9f71b11f7b57a8c87e36e6c98e92b9820c4ca"]
-  }
+  {}
 
 ::
 
   {
-    "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
     "funder_height": 1866594
   }
 
 ::
 
   {
-    "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
     "funder_height": 1866594,
     "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
     "spender_height": 0
@@ -675,9 +645,8 @@ as an input (spends it).
 
 **Notifications**
 
-  The client will receive a notification when the `status` of the outpoint changes, disregarding
-  changes to the `chaintip` item.
-  That is, any event that changes any field of the `status` dictionary (except the `chaintip` field)
+  The client will receive a notification when the `status` of the outpoint changes.
+  That is, any event that changes any field of the `status` dictionary
   results in a notification. Some examples:
 
   * a funding/spending tx appearing in the mempool if there was no such tx when the client subscribed
@@ -714,8 +683,7 @@ receives a notification.
   <- {
     "jsonrpc": "2.0",
     "result": {
-      "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
-      "funder_height": 1866594,
+      "funder_height": 1866594
     },
     "id": 4
   }
@@ -728,7 +696,6 @@ receives a notification.
       "1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf",
       1,
       {
-        "chaintip": [1866810, "5495aad5ec6518a1b8b904a22087753d0d43fa3e416c18c87e"],
         "funder_height": 1866594,
         "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
         "spender_height": 0


### PR DESCRIPTION
partially reverts 9c32658b4629196f8ff7043c210beb0786bc0dd1

ref https://github.com/spesmilo/electrum-protocol/pull/2#issuecomment-4855744448

-----

This does not revert the change of return type (array->dict) for
- `blockchain.scriptpubkey.get_history`
- `blockchain.scriptpubkey.get_mempool`
- `blockchain.scriptpubkey.listunspent`

as that makes it easier and more backwards-compatible to add new fields to the responses.