### PR TITLE
server.features: clarify pruning parameter.

### DIFF
--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -1470,8 +1470,9 @@ Return a list of features and services supported by the server.
   * *pruning*
 
     An integer, the pruning limit.  Omit or set to :const:`null` if
-    there is no pruning limit.  Should be the same as what would
-    suffix the letter ``p`` in the IRC real name.
+    there is no pruning limit.
+
+.. note:: *pruning* indicates how many spent transaction-history entries per address the server may retain.  It is not related to bitcoind's block pruning.
 
 **Example Result**
 


### PR DESCRIPTION
1. IRC for Electrum seems to have been deprecated for a while, and there's no other mention of it in the docs, so this is confusing.
2. pruning here isn't what I naively thought, either!

Thanks!
